### PR TITLE
Add support for by-name arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This trait wraps the API available on ```org.mockito.Mockito``` from the Java ve
 *   Eliminates parenthesis when possible to make the test code more readable
 *   Adds ```spyLambda[T]``` to allow spying lambdas (they don't work with the standard spy as they are created as final classes by the compiler)
 *   Supports mocking inline mixins like ```mock[MyClass with MyTrait]```
+*   Supports by-name arguments
 
 The companion object also extends the trait to allow the usage of the API without mixing-in the trait in case that's desired
 

--- a/src/main/java/org/mockito/internal/invocation/ArgumentsProcessor.java
+++ b/src/main/java/org/mockito/internal/invocation/ArgumentsProcessor.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2007 Mockito contributors
+ * This program is made available under the terms of the MIT License.
+ */
+package org.mockito.internal.invocation;
+
+import org.mockito.ArgumentMatcher;
+import org.mockito.internal.matchers.ArrayEquals;
+import org.mockito.internal.matchers.Equals;
+import scala.Function0;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * by Szczepan Faber, created at: 3/31/12
+ */
+public class ArgumentsProcessor {
+    // drops hidden synthetic parameters (last continuation parameter from Kotlin suspending functions)
+    // and expands varargs
+    public static Object[] expandArgs(MockitoMethod method, Object[] args) {
+        int nParams = method.getParameterTypes().length;
+        if (args != null && args.length > nParams)
+            args = Arrays.copyOf(args, nParams); // drop extra args (currently -- Kotlin continuation synthetic arg)
+        return expandVarArgs(method.isVarArgs(), unwrapByNameArgs(args));
+    }
+
+    private static Object[] unwrapByNameArgs(Object[] args) {
+        return Stream.of(args).map(a -> a instanceof Function0 ? ((Function0) a).apply() : a).toArray();
+    }
+
+    // expands array varArgs that are given by runtime (1, [a, b]) into true
+    // varArgs (1, a, b);
+    private static Object[] expandVarArgs(final boolean isVarArgs, final Object[] args) {
+        if (!isVarArgs || isNullOrEmpty(args) || args[args.length - 1] != null && !args[args.length - 1].getClass().isArray()) {
+            return args == null ? new Object[0] : args;
+        }
+
+        final int nonVarArgsCount = args.length - 1;
+        Object[] varArgs;
+        if (args[nonVarArgsCount] == null) {
+            // in case someone deliberately passed null varArg array
+            varArgs = new Object[] { null };
+        } else {
+            varArgs = ArrayEquals.createObjectArray(args[nonVarArgsCount]);
+        }
+        final int varArgsCount = varArgs.length;
+        Object[] newArgs = new Object[nonVarArgsCount + varArgsCount];
+        System.arraycopy(args, 0, newArgs, 0, nonVarArgsCount);
+        System.arraycopy(varArgs, 0, newArgs, nonVarArgsCount, varArgsCount);
+        return newArgs;
+    }
+
+    private static <T> boolean isNullOrEmpty(T[] array) {
+        return array == null || array.length == 0;
+    }
+
+    public static List<ArgumentMatcher> argumentsToMatchers(Object[] arguments) {
+        List<ArgumentMatcher> matchers = new ArrayList<>(arguments.length);
+        for (Object arg : arguments) {
+            if (arg != null && arg.getClass().isArray()) {
+                matchers.add(new ArrayEquals(arg));
+            } else {
+                matchers.add(new Equals(arg));
+            }
+        }
+        return matchers;
+    }
+
+
+}

--- a/src/test/scala/org/mockito/MockitoSugarTest.scala
+++ b/src/test/scala/org/mockito/MockitoSugarTest.scala
@@ -9,6 +9,8 @@ class MockitoSugarTest extends WordSpec with MockitoSugar with scalatest.Matcher
     def bar = "not mocked"
 
     def iHaveSomeDefaultArguments(noDefault: String, default: String = "default value"): String = s"$noDefault - $default"
+
+    def iHaveByNameArgs(normal: String, byName: => String): String = s"$normal - $byName"
   }
 
   class Bar {
@@ -76,6 +78,16 @@ class MockitoSugarTest extends WordSpec with MockitoSugar with scalatest.Matcher
       aMock.traitMethod() shouldBe 69
 
       verify(aMock).traitMethod(30)
+    }
+
+    "work with by-name arguments" in {
+      val aMock = mock[Foo]
+
+      when(aMock.iHaveByNameArgs(any, any)) thenReturn "mocked!"
+
+      aMock.iHaveByNameArgs("arg1", "arg2") shouldBe "mocked!"
+
+      verify(aMock).iHaveByNameArgs(eqTo("arg1"), startsWith("arg"))
     }
   }
 

--- a/src/test/scala/org/mockito/MockitoSugarTest.scala
+++ b/src/test/scala/org/mockito/MockitoSugarTest.scala
@@ -83,6 +83,18 @@ class MockitoSugarTest extends WordSpec with MockitoSugar with scalatest.Matcher
     "work with by-name arguments" in {
       val aMock = mock[Foo]
 
+      when(aMock.iHaveByNameArgs("arg1", "arg2")) thenReturn "mocked!"
+
+      aMock.iHaveByNameArgs("arg1", "arg2") shouldBe "mocked!"
+      aMock.iHaveByNameArgs("arg1", "arg3") shouldBe null
+
+      verify(aMock).iHaveByNameArgs("arg1", "arg2")
+      verify(aMock).iHaveByNameArgs("arg1", "arg3")
+    }
+
+    "work with by-name arguments and matchers" in {
+      val aMock = mock[Foo]
+
       when(aMock.iHaveByNameArgs(any, any)) thenReturn "mocked!"
 
       aMock.iHaveByNameArgs("arg1", "arg2") shouldBe "mocked!"


### PR DESCRIPTION
Add support for Scala by-name arguments on methods.

It currently relies on a hack which is overriding ```org.mockito.internal.invocation.ArgumentProcessor```, ideally I'd prefer some functionality (maybe on MockSettings) so anyone can specify some pre-processing on the arguments without having to hack it like this.
I'd say this could be merged like this for now, but I wonder if the core mockito team can think in a better solution.

the extra behaviour is added on lines 27 and 30-32 of ```org.mockito.internal.invocation.ArgumentProcessor```