### PR TITLE
Refactor value matchers and postFix dependent syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ aMock wasCalled sixTimesOn bar                              => aMock.bar wasCall
 theRealMethod willBe called by aMock bar                    => theRealMethod willBe called by aMock.bar
 new IllegalArgumentException willBe thrown by aMock bar     => new IllegalArgumentException willBe thrown by aMock.bar
 ```
+* eqToVal matcher syntax was improved to look more natural [Value Class Matchers](#value-class-matchers)
+```scala
+verify(myObj).myMethod(eqToVal[MyValueClass](456))    => verify(myObj).myMethod(eqToVal(MyValueClass(456)))
+myObj.myMethod(eqToVal[MyValueClass](456)) was called => myObj.myMethod(eqToVal(MyValueClass(456))) was called
+``` 
 
 ## Getting started
 
@@ -94,7 +99,7 @@ when(myObj.myMethod(anyVal[MyValueClass]) thenReturn "something"
 
 myObj.myMethod(MyValueClass(456)) shouldBe "something"
 
-verify(myObj).myMethod(eqToVal[MyValueClass](456))
+verify(myObj).myMethod(eqToVal(MyValueClass(456)))
 ```
 
 ## Improved ArgumentCaptor

--- a/README.md
+++ b/README.md
@@ -36,13 +36,17 @@ The library has independent developers, release cycle and versioning from core m
 * The usage of `org.mockito.Answer[T]` was removed from the API in favour of [Function Answers](#function-answers)
 * If you were using something like `doAnswer(_ => <something>).when ...` to lazily compute a return value when the method is actually called you should now write it like `doAnswer(<something>).when ...`, no need of passing a function as that argument is by-name
 * If you have chained return values like `when(myMock.foo) thenReturn "a" thenReturn "b" etc...` the syntax has changed a bit to `when(myMock.foo) thenReturn "a" andThen "b" etc...`
-* Idiomatic syntax has some changes to allow support of mixing values and argument matchers [Mix-and-Match](#mix-and-match)
+* Idiomatic syntax has some changes to remove postFix operations and also allow support for mixing values and argument matchers [Mix-and-Match](#mix-and-match)
 ```scala
+aMock.bar shouldCallRealMethod                              => aMock.bar shouldCall realMethod
+
 aMock wasCalled on bar                                      => aMock.bar was called
 aMock wasCalled onlyOn bar                                  => aMock.bar wasCalled onlyHere
-aMock was never called on bar                               => aMock.bar was never called
+aMock was never called on bar                               => aMock.bar wasNever called
 aMock wasCalled twiceOn bar                                 => aMock.bar wasCalled twice
 aMock wasCalled sixTimesOn bar                              => aMock.bar wasCalled sixTimes
+aMock was never called                                      => aMock.bar wasNever called
+aMock was never called again                                => aMock.bar wasNever calledAgain
 
 "mocked!" willBe returned by aMock bar                      => "mocked!" willBe returned by aMock.bar
 "mocked!" willBe answered by aMock bar                      => "mocked!" willBe answered by aMock.bar
@@ -245,7 +249,7 @@ val aMock = mock[Foo]
   
 when(aMock.bar) thenReturn "mocked!"                            <=> aMock.bar shouldReturn "mocked!"
 when(aMock.bar) thenReturn "mocked!" thenReturn "mocked again!" <=> aMock.bar shouldReturn "mocked!" andThen "mocked again!"
-when(aMock.bar) thenCallRealMethod()                            <=> aMock.bar shouldCallRealMethod
+when(aMock.bar) thenCallRealMethod()                            <=> aMock.bar shouldCall realMethod
 when(aMock.bar).thenThrow[IllegalArgumentException]             <=> aMock.bar.shouldThrow[IllegalArgumentException]
 when(aMock.bar) thenThrow new IllegalArgumentException          <=> aMock.bar shouldThrow new IllegalArgumentException
 when(aMock.bar) thenAnswer(_ => "mocked!")                      <=> aMock.bar shouldAnswer "mocked!"
@@ -257,14 +261,14 @@ doAnswer(_.getArgument[Int](0) * 10).when(aMock).bar(any)       <=> ((i: Int) =>
 doCallRealMethod.when(aMock).bar                                <=> theRealMethod willBe called by aMock.bar
 doThrow(new IllegalArgumentException).when(aMock).bar           <=> new IllegalArgumentException willBe thrown by aMock.bar
   
-verifyZeroInteractions(aMock)                                   <=> aMock was never called
+verifyZeroInteractions(aMock)                                   <=> aMock wasNever called
 verify(aMock).bar                                               <=> aMock.bar was called
 verify(aMock).bar(any)                                          <=> aMock.bar(*) was called
 verify(aMock, only).bar                                         <=> aMock.bar wasCalled onlyHere
-verify(aMock, never).bar                                        <=> aMock.bar was never called
+verify(aMock, never).bar                                        <=> aMock.bar wasNever called
 verify(aMock, times(2)).bar                                     <=> aMock.bar wasCalled twice
 verify(aMock, times(6)).bar                                     <=> aMock.bar wasCalled sixTimes
-verifyNoMoreInteractions(aMock)                                 <=> aMock was never called again
+verifyNoMoreInteractions(aMock)                                 <=> aMock wasNever calledAgain
 
 val order = inOrder(mock1, mock2)                               <=> InOrder(mock1, mock2) { implicit order =>
 order.verify(mock2).someMethod()                                <=>   mock2.someMethod() was called

--- a/core/src/main/scala/org/mockito/matchers/MacroBasedMatchers.scala
+++ b/core/src/main/scala/org/mockito/matchers/MacroBasedMatchers.scala
@@ -1,15 +1,17 @@
 package org.mockito.matchers
 
+import scala.language.experimental.macros
+
 trait MacroBasedMatchers {
 
   /**
-    * Wraps the standard 'ArgumentMatchers.eq()' matcher on the value class provided, this one requires the type to be explicit
-    */
-  def eqToVal[T](value: Any)(implicit valueClassMatchers: ValueClassMatchers[T]): T = valueClassMatchers.eqToVal(value)
+   * To be used instead of eqTo when the argument is a value class
+   */
+  def eqToVal[T](value: T): T = macro ValueClassMatchers.eqToValMatcher[T]
 
   /**
-    * Wraps the standard 'any' matcher on the value class provided, this one requires the type to be explicit
+    * To be used instead of any when the argument is a value class
     */
-  def anyVal[T](implicit valueClassMatchers: ValueClassMatchers[T]): T = valueClassMatchers.anyVal
+  def anyVal[T]: T = macro ValueClassMatchers.anyValMatcher[T]
 
 }

--- a/core/src/test/scala/user/org/mockito/DoSomethingTest.scala
+++ b/core/src/test/scala/user/org/mockito/DoSomethingTest.scala
@@ -1,10 +1,8 @@
 package user.org.mockito
 
-import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
+import org.mockito.{ ArgumentMatchersSugar, MockitoSugar }
 import org.mockito.invocation.InvocationOnMock
-import org.scalatest.{WordSpec, Matchers => ScalaTestMatchers}
-
-import scala.language.postfixOps
+import org.scalatest.{ WordSpec, Matchers => ScalaTestMatchers }
 
 class DoSomethingTest extends WordSpec with MockitoSugar with ScalaTestMatchers with ArgumentMatchersSugar {
 
@@ -54,7 +52,7 @@ class DoSomethingTest extends WordSpec with MockitoSugar with ScalaTestMatchers 
     "simplify answer API" in {
       val aMock = mock[Foo]
 
-      doAnswer((i: Int, s: String) => i * 10 + s.toInt toString).when(aMock).doSomethingWithThisIntAndString(*, *)
+      doAnswer((i: Int, s: String) => (i * 10 + s.toInt).toString).when(aMock).doSomethingWithThisIntAndString(*, *)
 
       aMock.doSomethingWithThisIntAndString(4, "2") shouldBe "42"
     }
@@ -62,7 +60,7 @@ class DoSomethingTest extends WordSpec with MockitoSugar with ScalaTestMatchers 
     "simplify answer API (invocation usage)" in {
       val aMock = mock[Foo]
 
-      doAnswer((i: InvocationOnMock) => i.getArgument[Int](0) * 10 + i.getArgument[String](1).toInt toString)
+      doAnswer((i: InvocationOnMock) => (i.getArgument[Int](0) * 10 + i.getArgument[String](1).toInt).toString)
         .when(aMock)
         .doSomethingWithThisIntAndString(*, *)
 

--- a/core/src/test/scala/user/org/mockito/IdiomaticMockitoTest.scala
+++ b/core/src/test/scala/user/org/mockito/IdiomaticMockitoTest.scala
@@ -3,12 +3,10 @@ package user.org.mockito
 import org.mockito.captor.ArgCaptor
 import org.mockito.exceptions.verification._
 import org.mockito.invocation.InvocationOnMock
-import org.mockito.{ArgumentMatchersSugar, IdiomaticMockito}
+import org.mockito.{ ArgumentMatchersSugar, IdiomaticMockito }
 import org.scalatest
 import org.scalatest.WordSpec
-import user.org.mockito.matchers.{ValueCaseClass, ValueClass}
-
-import scala.language.postfixOps
+import user.org.mockito.matchers.{ ValueCaseClass, ValueClass }
 
 class IdiomaticMockitoTest extends WordSpec with scalatest.Matchers with IdiomaticMockito with ArgumentMatchersSugar {
 
@@ -28,7 +26,7 @@ class IdiomaticMockitoTest extends WordSpec with scalatest.Matchers with Idiomat
 
     def highOrderFunction(f: Int => String): String = "not mocked"
 
-    def iReturnAFunction(v: Int): Int => String = i => i * v toString
+    def iReturnAFunction(v: Int): Int => String = i => (i * v).toString
 
     def iBlowUp(v: Int, v2: String): String = throw new IllegalArgumentException("I was called!")
 
@@ -78,7 +76,7 @@ class IdiomaticMockitoTest extends WordSpec with scalatest.Matchers with Idiomat
     "stub a real call" in {
       val aMock = mock[Foo]
 
-      aMock.bar shouldCallRealMethod
+      aMock.bar shouldCall realMethod
 
       aMock.bar shouldBe "not mocked"
     }
@@ -122,10 +120,10 @@ class IdiomaticMockitoTest extends WordSpec with scalatest.Matchers with Idiomat
       val aMock = mock[Foo]
 
       aMock.doSomethingWithThisInt(*) shouldAnswer ((i: Int) => i * 10 + 2)
-      aMock.doSomethingWithThisIntAndString(*, *) shouldAnswer ((i: Int, s: String) => i * 10 + s.toInt toString)
+      aMock.doSomethingWithThisIntAndString(*, *) shouldAnswer ((i: Int, s: String) => (i * 10 + s.toInt).toString)
       aMock.doSomethingWithThisIntAndStringAndBoolean(*, *, *) shouldAnswer ((i: Int,
                                                                               s: String,
-                                                                              boolean: Boolean) => (i * 10 + s.toInt toString) + boolean)
+                                                                              boolean: Boolean) => (i * 10 + s.toInt).toString + boolean)
 
       aMock.doSomethingWithThisInt(4) shouldBe 42
       aMock.doSomethingWithThisIntAndString(4, "2") shouldBe "42"
@@ -172,7 +170,7 @@ class IdiomaticMockitoTest extends WordSpec with scalatest.Matchers with Idiomat
     "allow using less params than method on answer stubbing" in {
       val aMock = mock[Foo]
 
-      aMock.doSomethingWithThisIntAndStringAndBoolean(*, *, *) shouldAnswer ((i: Int, s: String) => i * 10 + s.toInt toString)
+      aMock.doSomethingWithThisIntAndStringAndBoolean(*, *, *) shouldAnswer ((i: Int, s: String) => (i * 10 + s.toInt).toString)
 
       aMock.doSomethingWithThisIntAndStringAndBoolean(4, "2", v3 = true) shouldBe "42"
     }
@@ -197,7 +195,7 @@ class IdiomaticMockitoTest extends WordSpec with scalatest.Matchers with Idiomat
     "stub a method that returns a function" in {
       val aMock = mock[Foo]
 
-      aMock.iReturnAFunction(*) shouldReturn (_.toString) andThen (i => (i * 2) toString) andThenCallRealMethod ()
+      aMock.iReturnAFunction(*) shouldReturn (_.toString) andThen (i => (i * 2).toString) andThenCallRealMethod ()
 
       aMock.iReturnAFunction(0)(42) shouldBe "42"
       aMock.iReturnAFunction(0)(42) shouldBe "84"
@@ -227,8 +225,8 @@ class IdiomaticMockitoTest extends WordSpec with scalatest.Matchers with Idiomat
       val aSpy = spy(new Foo)
 
       ((i: Int) => i * 10 + 2) willBe answered by aSpy.doSomethingWithThisInt(*)
-      ((i: Int, s: String) => i * 10 + s.toInt toString) willBe answered by aSpy.doSomethingWithThisIntAndString(*, *)
-      ((i: Int, s: String, boolean: Boolean) => (i * 10 + s.toInt toString) + boolean) willBe answered by aSpy
+      ((i: Int, s: String) => (i * 10 + s.toInt).toString) willBe answered by aSpy.doSomethingWithThisIntAndString(*, *)
+      ((i: Int, s: String, boolean: Boolean) => (i * 10 + s.toInt).toString + boolean) willBe answered by aSpy
         .doSomethingWithThisIntAndStringAndBoolean(*, *, v3 = true)
       (() => "mocked!") willBe answered by aSpy.bar
       "mocked!" willBe answered by aSpy.baz
@@ -270,12 +268,13 @@ class IdiomaticMockitoTest extends WordSpec with scalatest.Matchers with Idiomat
     "check a mock was not used" in {
       val aMock = mock[Foo]
 
-      aMock was never called
+      aMock wasNever called
+      aMock wasNever called
 
       a[NoInteractionsWanted] should be thrownBy {
         aMock.baz
 
-        aMock was never called
+        aMock wasNever called
       }
     }
 
@@ -284,12 +283,12 @@ class IdiomaticMockitoTest extends WordSpec with scalatest.Matchers with Idiomat
     }
 
     "check a mock was not used (with setup)" in new SetupNeverUsed {
-      aMock was never called
+      aMock wasNever called
 
       a[NoInteractionsWanted] should be thrownBy {
         aMock.baz
 
-        aMock was never called
+        aMock wasNever called
       }
     }
 
@@ -319,15 +318,15 @@ class IdiomaticMockitoTest extends WordSpec with scalatest.Matchers with Idiomat
       }
     }
 
-    "check a method was never called" in {
+    "check a method wasNever called" in {
       val aMock = mock[Foo]
 
-      aMock.doSomethingWithThisIntAndString(*, "test") was never called
+      aMock.doSomethingWithThisIntAndString(*, "test") wasNever called
 
       a[NeverWantedButInvoked] should be thrownBy {
         aMock.doSomethingWithThisIntAndString(1, "test")
 
-        aMock.doSomethingWithThisIntAndString(*, "test") was never called
+        aMock.doSomethingWithThisIntAndString(*, "test") wasNever called
       }
     }
 
@@ -390,12 +389,12 @@ class IdiomaticMockitoTest extends WordSpec with scalatest.Matchers with Idiomat
 
       aMock.bar was called
 
-      aMock was never called again
+      aMock wasNever calledAgain
 
       a[NoInteractionsWanted] should be thrownBy {
         aMock.bar
 
-        aMock was never called again
+        aMock wasNever calledAgain
       }
     }
 

--- a/core/src/test/scala/user/org/mockito/MockitoSugarTest.scala
+++ b/core/src/test/scala/user/org/mockito/MockitoSugarTest.scala
@@ -2,11 +2,9 @@ package user.org.mockito
 
 import org.mockito.captor.ArgCaptor
 import org.mockito.invocation.InvocationOnMock
-import org.mockito.stubbing.{CallsRealMethods, DefaultAnswer}
-import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
-import org.scalatest.{Matchers, WordSpec}
-
-import scala.language.postfixOps
+import org.mockito.stubbing.{ CallsRealMethods, DefaultAnswer }
+import org.mockito.{ ArgumentMatchersSugar, MockitoSugar }
+import org.scalatest.{ Matchers, WordSpec }
 
 //noinspection RedundantDefaultArgument
 class MockitoSugarTest extends WordSpec with MockitoSugar with Matchers with ArgumentMatchersSugar {
@@ -65,7 +63,7 @@ class MockitoSugarTest extends WordSpec with MockitoSugar with Matchers with Arg
     "create a mock with nice answer API (multiple params)" in {
       val aMock = mock[Foo]
 
-      when(aMock.doSomethingWithThisIntAndString(*,*)) thenAnswer ((i: Int, s: String) => i * 10 + s.toInt toString)
+      when(aMock.doSomethingWithThisIntAndString(*, *)) thenAnswer ((i: Int, s: String) => (i * 10 + s.toInt).toString)
 
       aMock.doSomethingWithThisIntAndString(4, "2") shouldBe "42"
     }

--- a/core/src/test/scala/user/org/mockito/matchers/EqMatchersTest.scala
+++ b/core/src/test/scala/user/org/mockito/matchers/EqMatchersTest.scala
@@ -1,7 +1,6 @@
 package user.org.mockito.matchers
 
 import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
-import org.mockito.exceptions.verification.WantedButNotInvoked
 import org.scalactic.{Equality, StringNormalizations}
 import org.scalatest.{FlatSpec, Matchers => ScalaTestMatchers}
 
@@ -41,10 +40,12 @@ class EqMatchersTest extends FlatSpec with MockitoSugar with ScalaTestMatchers w
     val aMock = mock[Foo]
 
     aMock.valueClass(new ValueClass("meh"))
-    verify(aMock).valueClass(eqToVal[ValueClass]("meh"))
+    verify(aMock).valueClass(eqToVal(new ValueClass("meh")))
 
     aMock.valueCaseClass(ValueCaseClass(100))
-    verify(aMock).valueCaseClass(eqToVal[ValueCaseClass](100))
+    verify(aMock).valueCaseClass(eqToVal(ValueCaseClass(100)))
+    val expected = ValueCaseClass(100)
+    verify(aMock).valueCaseClass(eqToVal(expected))
   }
 
   "eqTo[T]" should "work with AnyRef" in {

--- a/macro/src/main/scala/org/mockito/Utils.scala
+++ b/macro/src/main/scala/org/mockito/Utils.scala
@@ -51,13 +51,18 @@ object Utils {
         case q"$_.shortThat[$_]($_)"   => true
         case q"$_.longThat[$_]($_)"    => true
 
-        case q"$_.n.>[$_]($_)($_)" => true
+        case q"$_.n.>[$_]($_)($_)"  => true
         case q"$_.n.>=[$_]($_)($_)" => true
-        case q"$_.n.<[$_]($_)($_)" => true
+        case q"$_.n.<[$_]($_)($_)"  => true
         case q"$_.n.<=[$_]($_)($_)" => true
-        case q"$_.n.=~[$_]($_)" => true
+        case q"$_.n.=~[$_]($_)"     => true
 
         case q"$_.Captor.asCapture[$_]($_)" => true
+
+        case q"($_(org.mockito.ArgumentMatchersSugar.eqTo[$_]($_)($_)): $_)"     => true
+        case q"(new $_(org.mockito.ArgumentMatchersSugar.eqTo[$_]($_)($_)): $_)" => true
+        case q"($_(org.mockito.ArgumentMatchers.any[$_]()): $_)"                 => true
+        case q"(new $_(org.mockito.ArgumentMatchers.any[$_]()): $_)"             => true
 
         case _ => false
       }

--- a/macro/src/main/scala/org/mockito/VerifyMacro.scala
+++ b/macro/src/main/scala/org/mockito/VerifyMacro.scala
@@ -35,25 +35,25 @@ object VerifyMacro {
     r
   }
 
-  def wasNotMacro[T: c.WeakTypeTag](c: blackbox.Context)(order: c.Expr[org.mockito.VerifyOrder]): c.Expr[Unit] = {
+  def wasNotMacro[T: c.WeakTypeTag](c: blackbox.Context)(called: c.Expr[Called.type])(order: c.Expr[org.mockito.VerifyOrder]): c.Expr[Unit] = {
     import c.universe._
 
     val r = c.Expr[Unit] {
       c.macroApplication match {
-        case q"$_.StubbingOps[$_]($_.this.$obj).was($_.never).called($_)" =>
+        case q"$_.StubbingOps[$_]($_.this.$obj).wasNever($_.called)($_)" =>
           q"org.mockito.MockitoSugar.verifyZeroInteractions($obj)"
 
-        case q"$_.StubbingOps[$_]($obj.$method[..$targs](...$args)).was($_.never).called($order)" =>
+        case q"$_.StubbingOps[$_]($obj.$method[..$targs](...$args)).wasNever($_.called)($order)" =>
           if (args.exists(a => hasMatchers(c)(a))) {
             val newArgs = args.map(a => transformArgs(c)(a))
             q"$order.verifyWithMode($obj, org.mockito.Mockito.never).$method[..$targs](...$newArgs)"
           } else
             q"$order.verifyWithMode($obj, org.mockito.Mockito.never).$method[..$targs](...$args)"
 
-        case q"$_.StubbingOps[$_]($obj.$method[..$targs]).was($_.never).called($order)" =>
+        case q"$_.StubbingOps[$_]($obj.$method[..$targs]).wasNever($_.called)($order)" =>
           q"$order.verifyWithMode($obj, org.mockito.Mockito.never).$method[..$targs]"
 
-        case q"$_.StubbingOps[$_]($obj).was($_.never).called($_)" =>
+        case q"$_.StubbingOps[$_]($obj).wasNever($_.called)($_)" =>
           q"org.mockito.MockitoSugar.verifyZeroInteractions($obj)"
 
         case o => throw new Exception(s"Couldn't recognize ${show(o)}")

--- a/macro/src/main/scala/org/mockito/matchers/ValueClassMatchers.scala
+++ b/macro/src/main/scala/org/mockito/matchers/ValueClassMatchers.scala
@@ -3,40 +3,33 @@ package org.mockito.matchers
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 
-trait ValueClassMatchers[T] {
-
-  def anyVal: T
-
-  def eqToVal(v: Any): T
-
-}
-
 object ValueClassMatchers {
 
-  implicit def materializeValueClassMatchers[T]: ValueClassMatchers[T] = macro materializeValueClassMatchersMacro[T]
-
-  def materializeValueClassMatchersMacro[T: c.WeakTypeTag](c: blackbox.Context): c.Expr[ValueClassMatchers[T]] = {
+  def eqToValMatcher[T: c.WeakTypeTag](c: blackbox.Context)(value: c.Expr[T]): c.Expr[T] = {
     import c.universe._
-    val tpe = weakTypeOf[T]
 
-    val param = tpe.decls
-      .collectFirst {
-        case m: MethodSymbol if m.isPrimaryConstructor ⇒ m
+    val r = c.Expr[T] {
+      c.macroApplication match {
+        case q"$_.eqToVal[$_]($clazz($arg))" => q"$clazz(org.mockito.ArgumentMatchersSugar.eqTo($arg))"
+        case q"$_.eqToVal[$_](new $clazz($arg))" => q"new $clazz(org.mockito.ArgumentMatchersSugar.eqTo($arg))"
+        case q"$_.eqToVal[$tpe]($arg)" =>
+          val companion = q"$tpe".symbol.companion
+          q"$companion.apply(org.mockito.ArgumentMatchersSugar.eqTo( $companion.unapply($arg).get ))"
+        case o => throw new Exception(s"Couldn't recognize ${show(o)}")
       }
-      .get
-      .paramLists
-      .head
-      .head
+    }
+    if (c.settings.contains("mockito-print-matcher")) println(show(r.tree))
+    r
+  }
 
-    val paramType = tpe.decl(param.name).typeSignature.finalResultType
+  def anyValMatcher[T: c.WeakTypeTag](c: blackbox.Context): c.Expr[T] = {
+    import c.universe._
 
-    val r = c.Expr[ValueClassMatchers[T]] {
-      q"""
-      new org.mockito.matchers.ValueClassMatchers[$tpe] {
-        override def anyVal: $tpe = new $tpe(org.mockito.ArgumentMatchers.any[$paramType]())
-        override def eqToVal(v: Any): $tpe = new $tpe(org.mockito.ArgumentMatchers.eq[$paramType](v.asInstanceOf[$paramType]))
+    val r = c.Expr[T] {
+      c.macroApplication match {
+        case q"$_.anyVal[$tpe]" => q"new $tpe(org.mockito.ArgumentMatchers.any())"
+        case o => throw new Exception(s"Couldn't recognize ${show(o)}")
       }
-    """
     }
     if (c.settings.contains("mockito-print-matcher")) println(show(r.tree))
     r


### PR DESCRIPTION
Refactor eqToVal matcher (Fixes #55)
Replace all syntax that requires postFix notation (Fixex #54) (@jozic please take a look)