### PR TITLE
Sanitise macros

### DIFF
--- a/core/src/test/scala/user/org/mockito/IdiomaticMockitoTest.scala
+++ b/core/src/test/scala/user/org/mockito/IdiomaticMockitoTest.scala
@@ -4,15 +4,14 @@ import org.mockito.captor.ArgCaptor
 import org.mockito.exceptions.verification._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.{ArgumentMatchersSugar, IdiomaticMockito}
-import org.scalatest
-import org.scalatest.WordSpec
+import org.scalatest.{Matchers, WordSpec}
 import user.org.mockito.matchers.{ValueCaseClass, ValueClass}
 
-class IdiomaticMockitoTest extends WordSpec with scalatest.Matchers with IdiomaticMockito with ArgumentMatchersSugar {
+class IdiomaticMockitoTest extends WordSpec with Matchers with IdiomaticMockito with ArgumentMatchersSugar {
 
   class Implicit[T]
 
-  class Foo {
+  class Org {
     def bar = "not mocked"
     def baz = "not mocked"
 
@@ -45,136 +44,136 @@ class IdiomaticMockitoTest extends WordSpec with scalatest.Matchers with Idiomat
 
   "StubbingOps" should {
     "stub a return value" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.bar shouldReturn "mocked!"
+      org.bar shouldReturn "mocked!"
 
-      aMock.bar shouldBe "mocked!"
+      org.bar shouldBe "mocked!"
     }
 
     "stub a value class return value" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.returnsValueCaseClass shouldReturn ValueCaseClass(100) andThen ValueCaseClass(200)
+      org.returnsValueCaseClass shouldReturn ValueCaseClass(100) andThen ValueCaseClass(200)
 
-      aMock.returnsValueCaseClass shouldBe ValueCaseClass(100)
-      aMock.returnsValueCaseClass shouldBe ValueCaseClass(200)
+      org.returnsValueCaseClass shouldBe ValueCaseClass(100)
+      org.returnsValueCaseClass shouldBe ValueCaseClass(200)
     }
 
     "stub multiple return values" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.bar shouldReturn "mocked!" andThen "mocked again!"
+      org.bar shouldReturn "mocked!" andThen "mocked again!"
 
-      aMock.bar shouldBe "mocked!"
-      aMock.bar shouldBe "mocked again!"
-      aMock.bar shouldBe "mocked again!"
+      org.bar shouldBe "mocked!"
+      org.bar shouldBe "mocked again!"
+      org.bar shouldBe "mocked again!"
     }
 
     "stub a real call" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.bar shouldCall realMethod
+      org.bar shouldCall realMethod
 
-      aMock.bar shouldBe "not mocked"
+      org.bar shouldBe "not mocked"
     }
 
     "stub an exception instance to be thrown" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.bar shouldThrow new IllegalArgumentException
+      org.bar shouldThrow new IllegalArgumentException
 
-      an[IllegalArgumentException] shouldBe thrownBy(aMock.bar)
+      an[IllegalArgumentException] shouldBe thrownBy(org.bar)
     }
 
     "chain exception and value" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.bar shouldThrow new IllegalArgumentException andThen "mocked!"
+      org.bar shouldThrow new IllegalArgumentException andThen "mocked!"
 
-      an[IllegalArgumentException] shouldBe thrownBy(aMock.bar)
-      aMock.bar shouldBe "mocked!"
+      an[IllegalArgumentException] shouldBe thrownBy(org.bar)
+      org.bar shouldBe "mocked!"
     }
 
     "chain value and exception" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.bar shouldReturn "mocked!" andThenThrow new IllegalArgumentException
+      org.bar shouldReturn "mocked!" andThenThrow new IllegalArgumentException
 
-      aMock.bar shouldBe "mocked!"
-      an[IllegalArgumentException] shouldBe thrownBy(aMock.bar)
+      org.bar shouldBe "mocked!"
+      an[IllegalArgumentException] shouldBe thrownBy(org.bar)
     }
 
     //useful if we want to delay the evaluation of whatever we are returning until the method is called
     "simplify stubbing an answer where we don't care about any param" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.bar shouldAnswer "mocked!"
+      org.bar shouldAnswer "mocked!"
 
-      aMock.bar shouldBe "mocked!"
+      org.bar shouldBe "mocked!"
     }
 
     "simplify answer API" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.doSomethingWithThisInt(*) shouldAnswer ((i: Int) => i * 10 + 2)
-      aMock.doSomethingWithThisIntAndString(*, *) shouldAnswer ((i: Int, s: String) => (i * 10 + s.toInt).toString)
-      aMock.doSomethingWithThisIntAndStringAndBoolean(*, *, *) shouldAnswer ((i: Int,
+      org.doSomethingWithThisInt(*) shouldAnswer ((i: Int) => i * 10 + 2)
+      org.doSomethingWithThisIntAndString(*, *) shouldAnswer ((i: Int, s: String) => (i * 10 + s.toInt).toString)
+      org.doSomethingWithThisIntAndStringAndBoolean(*, *, *) shouldAnswer ((i: Int,
                                                                               s: String,
                                                                               boolean: Boolean) => (i * 10 + s.toInt).toString + boolean)
 
-      aMock.doSomethingWithThisInt(4) shouldBe 42
-      aMock.doSomethingWithThisIntAndString(4, "2") shouldBe "42"
-      aMock.doSomethingWithThisIntAndStringAndBoolean(4, "2", v3 = true) shouldBe "42true"
+      org.doSomethingWithThisInt(4) shouldBe 42
+      org.doSomethingWithThisIntAndString(4, "2") shouldBe "42"
+      org.doSomethingWithThisIntAndStringAndBoolean(4, "2", v3 = true) shouldBe "42true"
     }
 
     "create a mock where I can mix matchers and normal parameters (answer)" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.doSomethingWithThisIntAndString(*, "test") shouldAnswer "mocked!"
+      org.doSomethingWithThisIntAndString(*, "test") shouldAnswer "mocked!"
 
-      aMock.doSomethingWithThisIntAndString(3, "test") shouldBe "mocked!"
-      aMock.doSomethingWithThisIntAndString(5, "test") shouldBe "mocked!"
-      aMock.doSomethingWithThisIntAndString(5, "est") shouldBe ""
+      org.doSomethingWithThisIntAndString(3, "test") shouldBe "mocked!"
+      org.doSomethingWithThisIntAndString(5, "test") shouldBe "mocked!"
+      org.doSomethingWithThisIntAndString(5, "est") shouldBe ""
     }
 
     "simplify answer API (invocation usage)" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.doSomethingWithThisInt(*) shouldAnswer ((i: InvocationOnMock) => i.getArgument[Int](0) * 10 + 2)
+      org.doSomethingWithThisInt(*) shouldAnswer ((i: InvocationOnMock) => i.getArgument[Int](0) * 10 + 2)
 
-      aMock.doSomethingWithThisInt(4) shouldBe 42
+      org.doSomethingWithThisInt(4) shouldBe 42
     }
 
     "chain answers" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.doSomethingWithThisInt(*) shouldAnswer ((i: Int) => i * 10 + 2) andThenAnswer ((i: Int) => i * 15 + 9)
+      org.doSomethingWithThisInt(*) shouldAnswer ((i: Int) => i * 10 + 2) andThenAnswer ((i: Int) => i * 15 + 9)
 
-      aMock.doSomethingWithThisInt(4) shouldBe 42
-      aMock.doSomethingWithThisInt(4) shouldBe 69
+      org.doSomethingWithThisInt(4) shouldBe 42
+      org.doSomethingWithThisInt(4) shouldBe 69
     }
 
     "chain answers (invocation usage)" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.doSomethingWithThisInt(*) shouldAnswer ((i: InvocationOnMock) => i.getArgument[Int](0) * 10 + 2) andThenAnswer (
+      org.doSomethingWithThisInt(*) shouldAnswer ((i: InvocationOnMock) => i.getArgument[Int](0) * 10 + 2) andThenAnswer (
           (i: InvocationOnMock) => i.getArgument[Int](0) * 15 + 9)
 
-      aMock.doSomethingWithThisInt(4) shouldBe 42
-      aMock.doSomethingWithThisInt(4) shouldBe 69
+      org.doSomethingWithThisInt(4) shouldBe 42
+      org.doSomethingWithThisInt(4) shouldBe 69
     }
 
     "allow using less params than method on answer stubbing" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.doSomethingWithThisIntAndStringAndBoolean(*, *, *) shouldAnswer ((i: Int, s: String) => (i * 10 + s.toInt).toString)
+      org.doSomethingWithThisIntAndStringAndBoolean(*, *, *) shouldAnswer ((i: Int, s: String) => (i * 10 + s.toInt).toString)
 
-      aMock.doSomethingWithThisIntAndStringAndBoolean(4, "2", v3 = true) shouldBe "42"
+      org.doSomethingWithThisIntAndStringAndBoolean(4, "2", v3 = true) shouldBe "42"
     }
 
     "stub a mock inline that has default args" in {
-      val aMock = mock[Foo]
+      val aMock = mock[Org]
 
       aMock.returnBar shouldReturn mock[Bar] andThen mock[Bar]
 
@@ -183,35 +182,35 @@ class IdiomaticMockitoTest extends WordSpec with scalatest.Matchers with Idiomat
     }
 
     "stub a high order function" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.highOrderFunction(*) shouldReturn "mocked!"
+      org.highOrderFunction(*) shouldReturn "mocked!"
 
-      aMock.highOrderFunction(_.toString) shouldBe "mocked!"
+      org.highOrderFunction(_.toString) shouldBe "mocked!"
     }
 
     "stub a method that returns a function" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.iReturnAFunction(*) shouldReturn (_.toString) andThen (i => (i * 2).toString) andThenCallRealMethod ()
+      org.iReturnAFunction(*) shouldReturn (_.toString) andThen (i => (i * 2).toString) andThenCallRealMethod ()
 
-      aMock.iReturnAFunction(0)(42) shouldBe "42"
-      aMock.iReturnAFunction(0)(42) shouldBe "84"
-      aMock.iReturnAFunction(3)(3) shouldBe "9"
+      org.iReturnAFunction(0)(42) shouldBe "42"
+      org.iReturnAFunction(0)(42) shouldBe "84"
+      org.iReturnAFunction(3)(3) shouldBe "9"
     }
   }
 
   "DoSomethingOps" should {
     "stub a value class return value" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      ValueCaseClass(100) willBe returned by aMock.returnsValueCaseClass
+      ValueCaseClass(100) willBe returned by org.returnsValueCaseClass
 
-      aMock.returnsValueCaseClass shouldBe ValueCaseClass(100)
+      org.returnsValueCaseClass shouldBe ValueCaseClass(100)
     }
 
     "stub a spy that would fail if the real impl is called" in {
-      val aSpy = spy(new Foo)
+      val aSpy = spy(new Org)
 
       an[IllegalArgumentException] should be thrownBy {
         aSpy.iBlowUp(*, *) shouldReturn "mocked!"
@@ -228,7 +227,7 @@ class IdiomaticMockitoTest extends WordSpec with scalatest.Matchers with Idiomat
     }
 
     "stub a spy with an answer" in {
-      val aSpy = spy(new Foo)
+      val aSpy = spy(new Org)
 
       ((i: Int) => i * 10 + 2) willBe answered by aSpy.doSomethingWithThisInt(*)
       ((i: Int, s: String) => (i * 10 + s.toInt).toString) willBe answered by aSpy.doSomethingWithThisIntAndString(*, *)
@@ -246,171 +245,171 @@ class IdiomaticMockitoTest extends WordSpec with scalatest.Matchers with Idiomat
     }
 
     "stub a real call" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      theRealMethod willBe called by aMock.doSomethingWithThisIntAndStringAndBoolean(*, *, v3 = true)
+      theRealMethod willBe called by org.doSomethingWithThisIntAndStringAndBoolean(*, *, v3 = true)
 
-      aMock.doSomethingWithThisIntAndStringAndBoolean(1, "2", v3 = true) shouldBe "not mocked"
-      aMock.doSomethingWithThisIntAndStringAndBoolean(1, "2", v3 = false) shouldBe ""
+      org.doSomethingWithThisIntAndStringAndBoolean(1, "2", v3 = true) shouldBe "not mocked"
+      org.doSomethingWithThisIntAndStringAndBoolean(1, "2", v3 = false) shouldBe ""
     }
 
     "stub a failure" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      new IllegalArgumentException willBe thrown by aMock.doSomethingWithThisIntAndStringAndBoolean(*, *, v3 = true)
+      new IllegalArgumentException willBe thrown by org.doSomethingWithThisIntAndStringAndBoolean(*, *, v3 = true)
 
-      aMock.doSomethingWithThisIntAndStringAndBoolean(1, "2", v3 = false)
+      org.doSomethingWithThisIntAndStringAndBoolean(1, "2", v3 = false)
 
       an[IllegalArgumentException] should be thrownBy {
-        aMock.doSomethingWithThisIntAndStringAndBoolean(1, "2", v3 = true)
+        org.doSomethingWithThisIntAndStringAndBoolean(1, "2", v3 = true)
       }
 
-      """"some value" willBe thrown by aMock bar""" shouldNot compile
+      """"some value" willBe thrown by org bar""" shouldNot compile
     }
   }
 
   "VerificationOps" should {
 
     "check a mock was not used" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock wasNever called
-      aMock wasNever called
+      org wasNever called
+      org wasNever called
 
       a[NoInteractionsWanted] should be thrownBy {
-        aMock.baz
+        org.baz
 
-        aMock wasNever called
+        org wasNever called
       }
     }
 
     trait SetupNeverUsed {
-      val aMock = mock[Foo]
+      val org = mock[Org]
     }
 
     "check a mock was not used (with setup)" in new SetupNeverUsed {
-      aMock wasNever called
+      org wasNever called
 
       a[NoInteractionsWanted] should be thrownBy {
-        aMock.baz
+        org.baz
 
-        aMock wasNever called
+        org wasNever called
       }
     }
 
     "check a method was called" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.bar
+      org.bar
 
-      aMock.bar was called
+      org.bar was called
 
       a[WantedButNotInvoked] should be thrownBy {
-        aMock.baz was called
+        org.baz was called
       }
     }
 
     "check a method was the only one called" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.bar
+      org.bar
 
-      aMock.bar wasCalled onlyHere
+      org.bar wasCalled onlyHere
 
       a[NoInteractionsWanted] should be thrownBy {
-        aMock.baz
+        org.baz
 
-        aMock.baz wasCalled onlyHere
+        org.baz wasCalled onlyHere
       }
     }
 
     "check a method wasNever called" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.doSomethingWithThisIntAndString(*, "test") wasNever called
+      org.doSomethingWithThisIntAndString(*, "test") wasNever called
 
       a[NeverWantedButInvoked] should be thrownBy {
-        aMock.doSomethingWithThisIntAndString(1, "test")
+        org.doSomethingWithThisIntAndString(1, "test")
 
-        aMock.doSomethingWithThisIntAndString(*, "test") wasNever called
+        org.doSomethingWithThisIntAndString(*, "test") wasNever called
       }
     }
 
     "check a method was called twice" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.doSomethingWithThisIntAndString(1, "test")
+      org.doSomethingWithThisIntAndString(1, "test")
 
       a[TooLittleActualInvocations] should be thrownBy {
-        aMock.doSomethingWithThisIntAndString(*, "test") wasCalled twice
+        org.doSomethingWithThisIntAndString(*, "test") wasCalled twice
       }
 
-      aMock.doSomethingWithThisIntAndString(2, "test")
+      org.doSomethingWithThisIntAndString(2, "test")
 
-      aMock.doSomethingWithThisIntAndString(*, "test") wasCalled twice
+      org.doSomethingWithThisIntAndString(*, "test") wasCalled twice
 
-      aMock.doSomethingWithThisIntAndString(3, "test")
+      org.doSomethingWithThisIntAndString(3, "test")
 
       a[TooManyActualInvocations] should be thrownBy {
-        aMock.doSomethingWithThisIntAndString(*, "test") wasCalled twice
+        org.doSomethingWithThisIntAndString(*, "test") wasCalled twice
       }
     }
 
     "check a method was called at least twice" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.doSomethingWithThisIntAndString(1, "test")
+      org.doSomethingWithThisIntAndString(1, "test")
 
       a[TooLittleActualInvocations] should be thrownBy {
-        aMock.doSomethingWithThisIntAndString(*, "test") wasCalled atLeastTwice
+        org.doSomethingWithThisIntAndString(*, "test") wasCalled atLeastTwice
       }
 
-      aMock.doSomethingWithThisIntAndString(2, "test")
+      org.doSomethingWithThisIntAndString(2, "test")
 
-      aMock.doSomethingWithThisIntAndString(*, "test") wasCalled atLeastTwice
+      org.doSomethingWithThisIntAndString(*, "test") wasCalled atLeastTwice
     }
 
     "check a method was called at most twice" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.doSomethingWithThisIntAndString(1, "test")
+      org.doSomethingWithThisIntAndString(1, "test")
 
-      aMock.doSomethingWithThisIntAndString(*, "test") wasCalled atMostTwice
+      org.doSomethingWithThisIntAndString(*, "test") wasCalled atMostTwice
 
-      aMock.doSomethingWithThisIntAndString(2, "test")
+      org.doSomethingWithThisIntAndString(2, "test")
 
-      aMock.doSomethingWithThisIntAndString(*, "test") wasCalled atMostTwice
+      org.doSomethingWithThisIntAndString(*, "test") wasCalled atMostTwice
 
-      aMock.doSomethingWithThisIntAndString(3, "test")
+      org.doSomethingWithThisIntAndString(3, "test")
 
       a[MoreThanAllowedActualInvocations] should be thrownBy {
-        aMock.doSomethingWithThisIntAndString(*, "test") wasCalled atMostTwice
+        org.doSomethingWithThisIntAndString(*, "test") wasCalled atMostTwice
       }
     }
 
     "check a mock was not called apart from the verified methods" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.bar
+      org.bar
 
-      aMock.bar was called
+      org.bar was called
 
-      aMock wasNever calledAgain
+      org wasNever calledAgain
 
       a[NoInteractionsWanted] should be thrownBy {
-        aMock.bar
+        org.bar
 
-        aMock wasNever calledAgain
+        org wasNever calledAgain
       }
     }
 
     "work with a captor" in {
-      val aMock     = mock[Foo]
+      val org     = mock[Org]
       val argCaptor = ArgCaptor[Int]
 
-      aMock.doSomethingWithThisIntAndString(42, "test")
+      org.doSomethingWithThisIntAndString(42, "test")
 
-      aMock.doSomethingWithThisIntAndString(argCaptor, "test") was called
+      org.doSomethingWithThisIntAndString(argCaptor, "test") was called
 
       argCaptor hasCaptured 42
 
@@ -420,7 +419,7 @@ class IdiomaticMockitoTest extends WordSpec with scalatest.Matchers with Idiomat
     }
 
     "check invocation order" in {
-      val mock1 = mock[Foo]
+      val mock1 = mock[Org]
       val mock2 = mock[Bar]
 
       mock1.bar
@@ -442,92 +441,92 @@ class IdiomaticMockitoTest extends WordSpec with scalatest.Matchers with Idiomat
 
   "mix arguments and raw parameters" should {
     "create a mock where I can mix matchers, normal and implicit parameters" in {
-      val aMock                                 = mock[Foo]
+      val org                                 = mock[Org]
       implicit val implicitValue: Implicit[Int] = mock[Implicit[Int]]
 
-      aMock.iHaveTypeParamsAndImplicits[Int, String](*, "test") shouldReturn "mocked!"
+      org.iHaveTypeParamsAndImplicits[Int, String](*, "test") shouldReturn "mocked!"
 
-      aMock.iHaveTypeParamsAndImplicits(3, "test") shouldBe "mocked!"
-      aMock.iHaveTypeParamsAndImplicits(5, "test") shouldBe "mocked!"
-      aMock.iHaveTypeParamsAndImplicits(5, "est") shouldBe ""
+      org.iHaveTypeParamsAndImplicits(3, "test") shouldBe "mocked!"
+      org.iHaveTypeParamsAndImplicits(5, "test") shouldBe "mocked!"
+      org.iHaveTypeParamsAndImplicits(5, "est") shouldBe ""
 
-      aMock.iHaveTypeParamsAndImplicits[Int, String](*, "test") wasCalled twice
+      org.iHaveTypeParamsAndImplicits[Int, String](*, "test") wasCalled twice
     }
 
     "handle the eqTo properly" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.doSomethingWithThisIntAndString(eqTo(1), "meh") shouldReturn "mocked!"
-      aMock.doSomethingWithThisIntAndString(1, "meh") shouldBe "mocked!"
-      aMock.doSomethingWithThisIntAndString(1, eqTo("meh")) was called
+      org.doSomethingWithThisIntAndString(eqTo(1), "meh") shouldReturn "mocked!"
+      org.doSomethingWithThisIntAndString(1, "meh") shouldBe "mocked!"
+      org.doSomethingWithThisIntAndString(1, eqTo("meh")) was called
     }
   }
 
   "value class matchers" should {
     "eqToVal works with new syntax" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.valueClass(1, eqToVal(new ValueClass("meh"))) shouldReturn "mocked!"
-      aMock.valueClass(1, new ValueClass("meh")) shouldBe "mocked!"
-      aMock.valueClass(1, eqToVal(new ValueClass("meh"))) was called
+      org.valueClass(1, eqToVal(new ValueClass("meh"))) shouldReturn "mocked!"
+      org.valueClass(1, new ValueClass("meh")) shouldBe "mocked!"
+      org.valueClass(1, eqToVal(new ValueClass("meh"))) was called
 
-      aMock.valueCaseClass(2, eqToVal(ValueCaseClass(100))) shouldReturn "mocked!"
-      aMock.valueCaseClass(2, ValueCaseClass(100)) shouldBe "mocked!"
-      aMock.valueCaseClass(2, eqToVal(ValueCaseClass(100))) was called
+      org.valueCaseClass(2, eqToVal(ValueCaseClass(100))) shouldReturn "mocked!"
+      org.valueCaseClass(2, ValueCaseClass(100)) shouldBe "mocked!"
+      org.valueCaseClass(2, eqToVal(ValueCaseClass(100))) was called
 
       val caseClassValue = ValueCaseClass(100)
-      aMock.valueCaseClass(3, eqToVal(caseClassValue)) shouldReturn "mocked!"
-      aMock.valueCaseClass(3, ValueCaseClass(100)) shouldBe "mocked!"
-      aMock.valueCaseClass(3, eqToVal(caseClassValue)) was called
+      org.valueCaseClass(3, eqToVal(caseClassValue)) shouldReturn "mocked!"
+      org.valueCaseClass(3, ValueCaseClass(100)) shouldBe "mocked!"
+      org.valueCaseClass(3, eqToVal(caseClassValue)) was called
 
-      aMock.valueCaseClass(*, ValueCaseClass(200)) shouldReturn "mocked!"
-      aMock.valueCaseClass(4, ValueCaseClass(200)) shouldBe "mocked!"
-      aMock.valueCaseClass(*, ValueCaseClass(200)) was called
+      org.valueCaseClass(*, ValueCaseClass(200)) shouldReturn "mocked!"
+      org.valueCaseClass(4, ValueCaseClass(200)) shouldBe "mocked!"
+      org.valueCaseClass(*, ValueCaseClass(200)) was called
     }
 
     "eqTo macro works with new syntax" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.valueClass(1, eqTo(new ValueClass("meh"))) shouldReturn "mocked!"
-      aMock.valueClass(1, new ValueClass("meh")) shouldBe "mocked!"
-      aMock.valueClass(1, eqTo(new ValueClass("meh"))) was called
+      org.valueClass(1, eqTo(new ValueClass("meh"))) shouldReturn "mocked!"
+      org.valueClass(1, new ValueClass("meh")) shouldBe "mocked!"
+      org.valueClass(1, eqTo(new ValueClass("meh"))) was called
 
-      aMock.valueCaseClass(2, eqTo(ValueCaseClass(100))) shouldReturn "mocked!"
-      aMock.valueCaseClass(2, ValueCaseClass(100)) shouldBe "mocked!"
-      aMock.valueCaseClass(2, eqTo(ValueCaseClass(100))) was called
+      org.valueCaseClass(2, eqTo(ValueCaseClass(100))) shouldReturn "mocked!"
+      org.valueCaseClass(2, ValueCaseClass(100)) shouldBe "mocked!"
+      org.valueCaseClass(2, eqTo(ValueCaseClass(100))) was called
 
       val caseClassValue = ValueCaseClass(100)
-      aMock.valueCaseClass(3, eqTo(caseClassValue)) shouldReturn "mocked!"
-      aMock.valueCaseClass(3, caseClassValue) shouldBe "mocked!"
-      aMock.valueCaseClass(3, eqTo(caseClassValue)) was called
+      org.valueCaseClass(3, eqTo(caseClassValue)) shouldReturn "mocked!"
+      org.valueCaseClass(3, caseClassValue) shouldBe "mocked!"
+      org.valueCaseClass(3, eqTo(caseClassValue)) was called
 
-      aMock.valueCaseClass(*, ValueCaseClass(200)) shouldReturn "mocked!"
-      aMock.valueCaseClass(4, ValueCaseClass(200)) shouldBe "mocked!"
-      aMock.valueCaseClass(*, ValueCaseClass(200)) was called
+      org.valueCaseClass(*, ValueCaseClass(200)) shouldReturn "mocked!"
+      org.valueCaseClass(4, ValueCaseClass(200)) shouldBe "mocked!"
+      org.valueCaseClass(*, ValueCaseClass(200)) was called
     }
 
     "anyVal works with new syntax" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.valueClass(1, anyVal[ValueClass]) shouldReturn "mocked!"
-      aMock.valueClass(1, new ValueClass("meh")) shouldBe "mocked!"
-      aMock.valueClass(1, anyVal[ValueClass]) was called
+      org.valueClass(1, anyVal[ValueClass]) shouldReturn "mocked!"
+      org.valueClass(1, new ValueClass("meh")) shouldBe "mocked!"
+      org.valueClass(1, anyVal[ValueClass]) was called
 
-      aMock.valueCaseClass(2, anyVal[ValueCaseClass]) shouldReturn "mocked!"
-      aMock.valueCaseClass(2, ValueCaseClass(100)) shouldBe "mocked!"
-      aMock.valueCaseClass(2, anyVal[ValueCaseClass]) was called
+      org.valueCaseClass(2, anyVal[ValueCaseClass]) shouldReturn "mocked!"
+      org.valueCaseClass(2, ValueCaseClass(100)) shouldBe "mocked!"
+      org.valueCaseClass(2, anyVal[ValueCaseClass]) was called
     }
 
     "any works with new syntax" in {
-      val aMock = mock[Foo]
+      val org = mock[Org]
 
-      aMock.valueClass(1, any[ValueClass]) shouldReturn "mocked!"
-      aMock.valueClass(1, new ValueClass("meh")) shouldBe "mocked!"
-      aMock.valueClass(1, any[ValueClass]) was called
+      org.valueClass(1, any[ValueClass]) shouldReturn "mocked!"
+      org.valueClass(1, new ValueClass("meh")) shouldBe "mocked!"
+      org.valueClass(1, any[ValueClass]) was called
 
-      aMock.valueCaseClass(2, any[ValueCaseClass]) shouldReturn "mocked!"
-      aMock.valueCaseClass(2, ValueCaseClass(100)) shouldBe "mocked!"
-      aMock.valueCaseClass(2, any[ValueCaseClass]) was called
+      org.valueCaseClass(2, any[ValueCaseClass]) shouldReturn "mocked!"
+      org.valueCaseClass(2, ValueCaseClass(100)) shouldBe "mocked!"
+      org.valueCaseClass(2, any[ValueCaseClass]) was called
     }
   }
 }

--- a/macro-common/src/main/scala/org/mockito/internal/ValueClassExtractor.scala
+++ b/macro-common/src/main/scala/org/mockito/internal/ValueClassExtractor.scala
@@ -38,19 +38,19 @@ object ValueClassExtractor {
     val r = if (isValueClass) {
 
       if (ScalaVersion.startsWith("2.12"))
-        c.Expr[ValueClassExtractor[VC]](q"new org.mockito.internal.ReflectionExtractor[$tpe]")
+        c.Expr[ValueClassExtractor[VC]](q"new _root_.org.mockito.internal.ReflectionExtractor[$tpe]")
       else if (ScalaVersion.startsWith("2.11"))
         c.Expr[ValueClassExtractor[VC]] {
           val companion = tpe.typeSymbol.companion
           q"""
-            new org.mockito.internal.ValueClassExtractor[$tpe] {
+            new _root_.org.mockito.internal.ValueClassExtractor[$tpe] {
               override def extract(vc: $tpe): Any = $companion.unapply(vc).get
             }
           """
         } else throw new Exception(s"Unsupported scala version $ScalaVersion")
 
     } else
-      c.Expr[ValueClassExtractor[VC]](q"new org.mockito.internal.NormalClassExtractor[$tpe]")
+      c.Expr[ValueClassExtractor[VC]](q"new _root_.org.mockito.internal.NormalClassExtractor[$tpe]")
 
     if (c.settings.contains("mockito-print-extractor")) println(show(r.tree))
 

--- a/macro/src/main/scala-2.11/org.mockito.matchers/MacroMatchers_211.scala
+++ b/macro/src/main/scala-2.11/org.mockito.matchers/MacroMatchers_211.scala
@@ -24,17 +24,17 @@ object MacroMatchers_211 {
     val r = c.Expr[T] {
       c.macroApplication match {
         case q"$_.eqTo[$tpe]($clazz($arg))($_)" if isValueClass(tpe) =>
-          q"$clazz(org.mockito.matchers.MacroMatchers_211.eqTo($arg))"
+          q"$clazz(_root_.org.mockito.matchers.MacroMatchers_211.eqTo($arg))"
 
         case q"$_.eqTo[$tpe](new $clazz($arg))($_)" if isValueClass(tpe) =>
-          q"new $clazz(org.mockito.matchers.MacroMatchers_211.eqTo($arg))"
+          q"new $clazz(_root_.org.mockito.matchers.MacroMatchers_211.eqTo($arg))"
 
         case q"$_.eqTo[$tpe]($arg)($_)" if isValueClass(tpe) && tpe.symbol.asClass.isCaseClass =>
           val companion = tpe.symbol.companion
-          q"$companion.apply( org.mockito.matchers.MacroMatchers_211.eqTo( $companion.unapply($arg).get ))"
+          q"$companion.apply(_root_.org.mockito.matchers.MacroMatchers_211.eqTo( $companion.unapply($arg).get ))"
 
         case q"$_.eqTo[$tpe]($arg)($eq)" =>
-          q"org.mockito.matchers.MacroMatchers_211.eqTo[$tpe]($arg)($eq)"
+          q"_root_.org.mockito.matchers.MacroMatchers_211.eqTo[$tpe]($arg)($eq)"
 
         case o => throw new Exception(s"Couldn't recognize ${show(o)}")
       }
@@ -48,11 +48,11 @@ object MacroMatchers_211 {
 
     val r = c.Expr[T] {
       c.macroApplication match {
-        case q"$_.eqToVal[$_]($clazz($arg))"     => q"$clazz(org.mockito.matchers.MacroMatchers_211.eqTo($arg))"
-        case q"$_.eqToVal[$_](new $clazz($arg))" => q"new $clazz(org.mockito.matchers.MacroMatchers_211.eqTo($arg))"
+        case q"$_.eqToVal[$_]($clazz($arg))"     => q"$clazz(_root_.org.mockito.matchers.MacroMatchers_211.eqTo($arg))"
+        case q"$_.eqToVal[$_](new $clazz($arg))" => q"new $clazz(_root_.org.mockito.matchers.MacroMatchers_211.eqTo($arg))"
         case q"$_.eqToVal[$tpe]($arg)" =>
           val companion = q"$tpe".symbol.companion
-          q"$companion.apply(org.mockito.matchers.MacroMatchers_211.eqTo( $companion.unapply($arg).get ))"
+          q"$companion.apply(_root_.org.mockito.matchers.MacroMatchers_211.eqTo( $companion.unapply($arg).get ))"
         case o => throw new Exception(s"Couldn't recognize ${show(o)}")
       }
     }

--- a/macro/src/main/scala/org/mockito/DoSomethingMacro.scala
+++ b/macro/src/main/scala/org/mockito/DoSomethingMacro.scala
@@ -16,12 +16,12 @@ object DoSomethingMacro {
         case q"$_.DoSomethingOps[$r]($v).willBe($_.returned).by[$_]($obj.$method[..$targs](...$args))" =>
           if (args.exists(a => hasMatchers(c)(a))) {
             val newArgs = args.map(a => transformArgs(c)(a))
-            q"org.mockito.MockitoSugar.doReturn[$r]($v).when($obj).$method[..$targs](...$newArgs)"
+            q"_root_.org.mockito.MockitoSugar.doReturn[$r]($v).when($obj).$method[..$targs](...$newArgs)"
           } else
-            q"org.mockito.MockitoSugar.doReturn[$r]($v).when($obj).$method[..$targs](...$args)"
+            q"_root_.org.mockito.MockitoSugar.doReturn[$r]($v).when($obj).$method[..$targs](...$args)"
 
         case q"$_.DoSomethingOps[$r]($v).willBe($_.returned).by[$_]($obj.$method[..$targs])" =>
-          q"org.mockito.MockitoSugar.doReturn[$r]($v).when($obj).$method[..$targs]"
+          q"_root_.org.mockito.MockitoSugar.doReturn[$r]($v).when($obj).$method[..$targs]"
 
         case o => throw new Exception(s"Couldn't recognize ${show(o)}")
       }
@@ -38,12 +38,12 @@ object DoSomethingMacro {
         case q"$_.DoSomethingOps[$r]($v).willBe($_.answered).by[$_]($obj.$method[..$targs](...$args))" =>
           if (args.exists(a => hasMatchers(c)(a))) {
             val newArgs = args.map(a => transformArgs(c)(a))
-            q"org.mockito.MockitoSugar.doAnswer($v).when($obj).$method[..$targs](...$newArgs)"
+            q"_root_.org.mockito.MockitoSugar.doAnswer($v).when($obj).$method[..$targs](...$newArgs)"
           } else
-            q"org.mockito.MockitoSugar.doAnswer($v).when($obj).$method[..$targs](...$args)"
+            q"_root_.org.mockito.MockitoSugar.doAnswer($v).when($obj).$method[..$targs](...$args)"
 
         case q"$_.DoSomethingOps[$r]($v).willBe($_.answered).by[$_]($obj.$method[..$targs])" =>
-          q"org.mockito.MockitoSugar.doAnswer($v).when($obj).$method[..$targs]"
+          q"_root_.org.mockito.MockitoSugar.doAnswer($v).when($obj).$method[..$targs]"
 
         case o => throw new Exception(s"Couldn't recognize ${show(o)}")
       }
@@ -60,12 +60,12 @@ object DoSomethingMacro {
         case q"$_.ThrowSomethingOps[$_]($v).willBe($_.thrown).by[$_]($obj.$method[..$targs](...$args))" =>
           if (args.exists(a => hasMatchers(c)(a))) {
             val newArgs = args.map(a => transformArgs(c)(a))
-            q"org.mockito.MockitoSugar.doThrow($v).when($obj).$method[..$targs](...$newArgs)"
+            q"_root_.org.mockito.MockitoSugar.doThrow($v).when($obj).$method[..$targs](...$newArgs)"
           } else
-            q"org.mockito.MockitoSugar.doThrow($v).when($obj).$method[..$targs](...$args)"
+            q"_root_.org.mockito.MockitoSugar.doThrow($v).when($obj).$method[..$targs](...$args)"
 
         case q"$_.ThrowSomethingOps[$_]($v).willBe($_.thrown).by[$_]($obj.$method[..$targs])" =>
-          q"org.mockito.MockitoSugar.doThrow($v).when($obj).$method[..$targs]"
+          q"_root_.org.mockito.MockitoSugar.doThrow($v).when($obj).$method[..$targs]"
 
         case o => throw new Exception(s"Couldn't recognize ${show(o)}")
       }
@@ -82,12 +82,12 @@ object DoSomethingMacro {
         case q"$_.theRealMethod.willBe($_.called).by[$_]($obj.$method[..$targs](...$args))" =>
           if (args.exists(a => hasMatchers(c)(a))) {
             val newArgs = args.map(a => transformArgs(c)(a))
-            q"org.mockito.MockitoSugar.doCallRealMethod.when($obj).$method[..$targs](...$newArgs)"
+            q"_root_.org.mockito.MockitoSugar.doCallRealMethod.when($obj).$method[..$targs](...$newArgs)"
           } else
-            q"org.mockito.MockitoSugar.doCallRealMethod.when($obj).$method[..$targs](...$args)"
+            q"_root_.org.mockito.MockitoSugar.doCallRealMethod.when($obj).$method[..$targs](...$args)"
 
         case q"$_.theRealMethod.willBe($_.called).by[$_]($obj.$method[..$targs])" =>
-          q"org.mockito.MockitoSugar.doCallRealMethod.when($obj).$method[..$targs]"
+          q"_root_.org.mockito.MockitoSugar.doCallRealMethod.when($obj).$method[..$targs]"
 
         case o => throw new Exception(s"Couldn't recognize ${show(o)}")
       }

--- a/macro/src/main/scala/org/mockito/Utils.scala
+++ b/macro/src/main/scala/org/mockito/Utils.scala
@@ -61,9 +61,9 @@ object Utils {
 
         case q"$_.Captor.asCapture[$_]($_)" => true
 
-        case q"(org.mockito.matchers.MacroMatchers_211.eqTo[$_](...$_): $_)"         => true
-        case q"($_(org.mockito.matchers.MacroMatchers_211.eqTo[$_](...$_)): $_)"     => true
-        case q"(new $_(org.mockito.matchers.MacroMatchers_211.eqTo[$_](...$_)): $_)" => true
+        case q"($_.MacroMatchers_211.eqTo[$_](...$_): $_)"         => true
+        case q"($_($_.MacroMatchers_211.eqTo[$_](...$_)): $_)"     => true
+        case q"(new $_($_.MacroMatchers_211.eqTo[$_](...$_)): $_)" => true
 
         case _ => false
       }
@@ -77,7 +77,7 @@ object Utils {
     if (isMatcher(c)(arg)) arg
     else
       arg match {
-        case q"$a" => q"org.mockito.ArgumentMatchersSugar.eqTo($a)"
+        case q"$a" => q"_root_.org.mockito.ArgumentMatchersSugar.eqTo($a)"
       }
   }
 }

--- a/macro/src/main/scala/org/mockito/VerifyMacro.scala
+++ b/macro/src/main/scala/org/mockito/VerifyMacro.scala
@@ -13,7 +13,7 @@ object Called {
 
 object VerifyMacro {
 
-  def wasMacro[T: c.WeakTypeTag](c: blackbox.Context)(called: c.Expr[Called.type])(order: c.Expr[org.mockito.VerifyOrder]): c.Expr[Unit] = {
+  def wasMacro[T: c.WeakTypeTag](c: blackbox.Context)(called: c.Expr[Called.type])(order: c.Expr[VerifyOrder]): c.Expr[Unit] = {
     import c.universe._
 
     val r = c.Expr[Unit] {
@@ -35,26 +35,26 @@ object VerifyMacro {
     r
   }
 
-  def wasNotMacro[T: c.WeakTypeTag](c: blackbox.Context)(called: c.Expr[Called.type])(order: c.Expr[org.mockito.VerifyOrder]): c.Expr[Unit] = {
+  def wasNotMacro[T: c.WeakTypeTag](c: blackbox.Context)(called: c.Expr[Called.type])(order: c.Expr[VerifyOrder]): c.Expr[Unit] = {
     import c.universe._
 
     val r = c.Expr[Unit] {
       c.macroApplication match {
         case q"$_.StubbingOps[$_]($_.this.$obj).wasNever($_.called)($_)" =>
-          q"org.mockito.MockitoSugar.verifyZeroInteractions($obj)"
+          q"_root_.org.mockito.MockitoSugar.verifyZeroInteractions($obj)"
 
         case q"$_.StubbingOps[$_]($obj.$method[..$targs](...$args)).wasNever($_.called)($order)" =>
           if (args.exists(a => hasMatchers(c)(a))) {
             val newArgs = args.map(a => transformArgs(c)(a))
-            q"$order.verifyWithMode($obj, org.mockito.Mockito.never).$method[..$targs](...$newArgs)"
+            q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.never).$method[..$targs](...$newArgs)"
           } else
-            q"$order.verifyWithMode($obj, org.mockito.Mockito.never).$method[..$targs](...$args)"
+            q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.never).$method[..$targs](...$args)"
 
         case q"$_.StubbingOps[$_]($obj.$method[..$targs]).wasNever($_.called)($order)" =>
-          q"$order.verifyWithMode($obj, org.mockito.Mockito.never).$method[..$targs]"
+          q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.never).$method[..$targs]"
 
         case q"$_.StubbingOps[$_]($obj).wasNever($_.called)($_)" =>
-          q"org.mockito.MockitoSugar.verifyZeroInteractions($obj)"
+          q"_root_.org.mockito.MockitoSugar.verifyZeroInteractions($obj)"
 
         case o => throw new Exception(s"Couldn't recognize ${show(o)}")
       }
@@ -65,7 +65,7 @@ object VerifyMacro {
 
   case class Times(times: Int)
 
-  def wasMacroTimes[T: c.WeakTypeTag](c: blackbox.Context)(t: c.Expr[Times])(order: c.Expr[org.mockito.VerifyOrder]): c.Expr[Unit] = {
+  def wasMacroTimes[T: c.WeakTypeTag](c: blackbox.Context)(t: c.Expr[Times])(order: c.Expr[VerifyOrder]): c.Expr[Unit] = {
     import c.universe._
 
     val r = c.Expr[Unit] {
@@ -73,12 +73,12 @@ object VerifyMacro {
         case q"$_.StubbingOps[$_]($obj.$method[..$targs](...$args)).wasCalled($times)($order)" =>
           if (args.exists(a => hasMatchers(c)(a))) {
             val newArgs = args.map(a => transformArgs(c)(a))
-            q"$order.verifyWithMode($obj, org.mockito.Mockito.times($times.times)).$method[..$targs](...$newArgs)"
+            q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.times($times.times)).$method[..$targs](...$newArgs)"
           } else
-            q"$order.verifyWithMode($obj, org.mockito.Mockito.times($times.times)).$method[..$targs](...$args)"
+            q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.times($times.times)).$method[..$targs](...$args)"
 
         case q"$_.StubbingOps[$_]($obj.$method[..$targs]).wasCalled($times)($order)" =>
-          q"$order.verifyWithMode($obj, org.mockito.Mockito.times($times.times)).$method[..$targs]"
+          q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.times($times.times)).$method[..$targs]"
 
         case o => throw new Exception(s"Couldn't recognize ${show(o)}")
       }
@@ -89,7 +89,7 @@ object VerifyMacro {
 
   case class AtLeast(times: Int)
 
-  def wasMacroAtLeast[T: c.WeakTypeTag](c: blackbox.Context)(t: c.Expr[AtLeast])(order: c.Expr[org.mockito.VerifyOrder]): c.Expr[Unit] = {
+  def wasMacroAtLeast[T: c.WeakTypeTag](c: blackbox.Context)(t: c.Expr[AtLeast])(order: c.Expr[VerifyOrder]): c.Expr[Unit] = {
     import c.universe._
 
     val r = c.Expr[Unit] {
@@ -97,12 +97,12 @@ object VerifyMacro {
         case q"$_.StubbingOps[$_]($obj.$method[..$targs](...$args)).wasCalled($times)($order)" =>
           if (args.exists(a => hasMatchers(c)(a))) {
             val newArgs = args.map(a => transformArgs(c)(a))
-            q"$order.verifyWithMode($obj, org.mockito.Mockito.atLeast($times.times)).$method[..$targs](...$newArgs)"
+            q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.atLeast($times.times)).$method[..$targs](...$newArgs)"
           } else
-            q"$order.verifyWithMode($obj, org.mockito.Mockito.atLeast($times.times)).$method[..$targs](...$args)"
+            q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.atLeast($times.times)).$method[..$targs](...$args)"
 
         case q"$_.StubbingOps[$_]($obj.$method[..$targs]).wasCalled($times)($order)" =>
-          q"$order.verifyWithMode($obj, org.mockito.Mockito.atLeast($times.times)).$method[..$targs]"
+          q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.atLeast($times.times)).$method[..$targs]"
 
         case o => throw new Exception(s"Couldn't recognize ${show(o)}")
       }
@@ -113,7 +113,7 @@ object VerifyMacro {
 
   case class AtMost(times: Int)
 
-  def wasMacroAtMost[T: c.WeakTypeTag](c: blackbox.Context)(t: c.Expr[AtMost])(order: c.Expr[org.mockito.VerifyOrder]): c.Expr[Unit] = {
+  def wasMacroAtMost[T: c.WeakTypeTag](c: blackbox.Context)(t: c.Expr[AtMost])(order: c.Expr[VerifyOrder]): c.Expr[Unit] = {
     import c.universe._
 
     val r = c.Expr[Unit] {
@@ -121,12 +121,12 @@ object VerifyMacro {
         case q"$_.StubbingOps[$_]($obj.$method[..$targs](...$args)).wasCalled($times)($order)" =>
           if (args.exists(a => hasMatchers(c)(a))) {
             val newArgs = args.map(a => transformArgs(c)(a))
-            q"$order.verifyWithMode($obj, org.mockito.Mockito.atMost($times.times)).$method[..$targs](...$newArgs)"
+            q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.atMost($times.times)).$method[..$targs](...$newArgs)"
           } else
-            q"$order.verifyWithMode($obj, org.mockito.Mockito.atMost($times.times)).$method[..$targs](...$args)"
+            q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.atMost($times.times)).$method[..$targs](...$args)"
 
         case q"$_.StubbingOps[$_]($obj.$method[..$targs]).wasCalled($times)($order)" =>
-          q"$order.verifyWithMode($obj, org.mockito.Mockito.atMost($times.times)).$method[..$targs]"
+          q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.atMost($times.times)).$method[..$targs]"
 
         case o => throw new Exception(s"Couldn't recognize ${show(o)}")
       }
@@ -137,7 +137,7 @@ object VerifyMacro {
 
   class OnlyOn
 
-  def wasMacroOnlyOn[T: c.WeakTypeTag](c: blackbox.Context)(t: c.Expr[OnlyOn])(order: c.Expr[org.mockito.VerifyOrder]): c.Expr[Unit] = {
+  def wasMacroOnlyOn[T: c.WeakTypeTag](c: blackbox.Context)(t: c.Expr[OnlyOn])(order: c.Expr[VerifyOrder]): c.Expr[Unit] = {
     import c.universe._
 
     val r = c.Expr[Unit] {
@@ -145,12 +145,12 @@ object VerifyMacro {
         case q"$_.StubbingOps[$_]($obj.$method[..$targs](...$args)).wasCalled($_)($order)" =>
           if (args.exists(a => hasMatchers(c)(a))) {
             val newArgs = args.map(a => transformArgs(c)(a))
-            q"$order.verifyWithMode($obj, org.mockito.Mockito.only).$method[..$targs](...$newArgs)"
+            q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.only).$method[..$targs](...$newArgs)"
           } else
-            q"$order.verifyWithMode($obj, org.mockito.Mockito.only).$method[..$targs](...$args)"
+            q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.only).$method[..$targs](...$args)"
 
         case q"$_.StubbingOps[$_]($obj.$method[..$targs]).wasCalled($_)($order)" =>
-          q"$order.verifyWithMode($obj, org.mockito.Mockito.only).$method[..$targs]"
+          q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.only).$method[..$targs]"
 
         case o => throw new Exception(s"Couldn't recognize ${show(o)}")
       }

--- a/macro/src/main/scala/org/mockito/WhenMacro.scala
+++ b/macro/src/main/scala/org/mockito/WhenMacro.scala
@@ -1,16 +1,15 @@
 package org.mockito
 
-import org.mockito.stubbing.{ ScalaFirstStubbing, ScalaOngoingStubbing }
 import org.mockito.Utils._
-import org.mockito.internal.ValueClassExtractor
+import org.mockito.stubbing.{ScalaFirstStubbing, ScalaOngoingStubbing}
 
 import scala.language.experimental.macros
-import scala.reflect.macros.blackbox
 import scala.reflect.ClassTag
+import scala.reflect.macros.blackbox
 
 object WhenMacro {
 
-  class ReturnActions[T: ValueClassExtractor](os: ScalaFirstStubbing[T]) {
+  class ReturnActions[T](os: ScalaFirstStubbing[T]) {
     def apply(value: T): ScalaOngoingStubbing[T] = os thenReturn value
   }
 
@@ -22,12 +21,12 @@ object WhenMacro {
         case q"$_.StubbingOps[$t]($obj.$method[..$targs](...$args)).shouldReturn" =>
           if (args.exists(a => hasMatchers(c)(a))) {
             val newArgs = args.map(a => transformArgs(c)(a))
-            q"new org.mockito.WhenMacro.ReturnActions(org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$newArgs)))"
+            q"new _root_.org.mockito.WhenMacro.ReturnActions(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$newArgs)))"
           } else
-            q"new org.mockito.WhenMacro.ReturnActions(org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$args)))"
+            q"new _root_.org.mockito.WhenMacro.ReturnActions(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$args)))"
 
         case q"$_.StubbingOps[$t]($obj.$method[..$targs]).shouldReturn" =>
-          q"new org.mockito.WhenMacro.ReturnActions(org.mockito.Mockito.when[$t]($obj.$method[..$targs]))"
+          q"new _root_.org.mockito.WhenMacro.ReturnActions(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs]))"
 
         case o => throw new Exception(s"Couldn't recognize ${show(o)}")
       }
@@ -46,12 +45,12 @@ object WhenMacro {
         case q"$_.StubbingOps[$t]($obj.$method[..$targs](...$args)).shouldCall($_.realMethod)" =>
           if (args.exists(a => hasMatchers(c)(a))) {
             val newArgs = args.map(a => transformArgs(c)(a))
-            q"new org.mockito.stubbing.ScalaOngoingStubbing(org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$newArgs)).thenCallRealMethod())"
+            q"new _root_.org.mockito.stubbing.ScalaOngoingStubbing(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$newArgs)).thenCallRealMethod())"
           } else
-            q"new org.mockito.stubbing.ScalaOngoingStubbing(org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$args)).thenCallRealMethod())"
+            q"new _root_.org.mockito.stubbing.ScalaOngoingStubbing(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$args)).thenCallRealMethod())"
 
         case q"$_.StubbingOps[$t]($obj.$method[..$targs]).shouldCall($_.realMethod)" =>
-          q"new org.mockito.stubbing.ScalaOngoingStubbing(org.mockito.Mockito.when[$t]($obj.$method[..$targs]).thenCallRealMethod())"
+          q"new _root_.org.mockito.stubbing.ScalaOngoingStubbing(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs]).thenCallRealMethod())"
 
         case o => throw new Exception(s"Couldn't recognize ${show(o)}")
       }
@@ -72,12 +71,12 @@ object WhenMacro {
         case q"$_.StubbingOps[$t]($obj.$method[..$targs](...$args)).shouldThrow" =>
           if (args.exists(a => hasMatchers(c)(a))) {
             val newArgs = args.map(a => transformArgs(c)(a))
-            q"new org.mockito.WhenMacro.ThrowActions(org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$newArgs)))"
+            q"new _root_.org.mockito.WhenMacro.ThrowActions(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$newArgs)))"
           } else
-            q"new org.mockito.WhenMacro.ThrowActions(org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$args)))"
+            q"new _root_.org.mockito.WhenMacro.ThrowActions(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$args)))"
 
         case q"$_.StubbingOps[$t]($obj.$method[..$targs]).shouldThrow" =>
-          q"new org.mockito.WhenMacro.ThrowActions(org.mockito.Mockito.when[$t]($obj.$method[..$targs]))"
+          q"new _root_.org.mockito.WhenMacro.ThrowActions(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs]))"
 
         case o => throw new Exception(s"Couldn't recognize ${show(o)}")
       }
@@ -86,7 +85,7 @@ object WhenMacro {
     r
   }
 
-  class AnswerActions[T: ValueClassExtractor](os: ScalaFirstStubbing[T]) {
+  class AnswerActions[T](os: ScalaFirstStubbing[T]) {
     def apply(f: => T): ScalaOngoingStubbing[T]                  = os thenAnswer f
     def apply[P0: ClassTag](f: P0 => T): ScalaOngoingStubbing[T] = os thenAnswer f
     def apply[P0, P1](f: (P0, P1) => T): ScalaOngoingStubbing[T] = os thenAnswer f
@@ -120,12 +119,12 @@ object WhenMacro {
         case q"$_.StubbingOps[$t]($obj.$method[..$targs](...$args)).shouldAnswer" =>
           if (args.exists(a => hasMatchers(c)(a))) {
             val newArgs = args.map(a => transformArgs(c)(a))
-            q"new org.mockito.WhenMacro.AnswerActions(org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$newArgs)))"
+            q"new _root_.org.mockito.WhenMacro.AnswerActions(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$newArgs)))"
           } else
-            q"new org.mockito.WhenMacro.AnswerActions(org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$args)))"
+            q"new _root_.org.mockito.WhenMacro.AnswerActions(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$args)))"
 
         case q"$_.StubbingOps[$t]($obj.$method[..$targs]).shouldAnswer" =>
-          q"new org.mockito.WhenMacro.AnswerActions(org.mockito.Mockito.when[$t]($obj.$method[..$targs]))"
+          q"new _root_.org.mockito.WhenMacro.AnswerActions(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs]))"
 
         case o => throw new Exception(s"Couldn't recognize ${show(o)}")
       }

--- a/macro/src/main/scala/org/mockito/captor/Captor.scala
+++ b/macro/src/main/scala/org/mockito/captor/Captor.scala
@@ -56,11 +56,11 @@ object Captor {
       val paramType = tpe.decl(param.name).typeSignature.finalResultType
 
       q"""
-      new org.mockito.captor.Captor[$tpe] {
+      new _root_.org.mockito.captor.Captor[$tpe] {
 
-        import scala.collection.JavaConverters._
+        import _root_.scala.collection.JavaConverters._
 
-        private val argumentCaptor = org.mockito.ArgumentCaptor.forClass(classOf[$paramType])
+        private val argumentCaptor = _root_.org.mockito.ArgumentCaptor.forClass(classOf[$paramType])
 
         override def capture: $tpe = new $tpe(argumentCaptor.capture())
 
@@ -70,7 +70,7 @@ object Captor {
       }
     """
     } else
-      c.Expr[Captor[T]](q"new org.mockito.captor.WrapperCaptor[$tpe]")
+      c.Expr[Captor[T]](q"new _root_.org.mockito.captor.WrapperCaptor[$tpe]")
 
     if (c.settings.contains("mockito-print-captor")) println(show(r.tree))
     r

--- a/macro/src/main/scala/org/mockito/matchers/MacroMatchers.scala
+++ b/macro/src/main/scala/org/mockito/matchers/MacroMatchers.scala
@@ -25,12 +25,12 @@ object MacroMatchers {
 
     val r = if (isValueClass) c.Expr[AnyMatcher[T]] {
       q"""
-      new org.mockito.matchers.AnyMatcher[$tpe] {
-        override def any: $tpe = new $tpe(org.mockito.ArgumentMatchers.any())
+      new _root_.org.mockito.matchers.AnyMatcher[$tpe] {
+        override def any: $tpe = new $tpe(_root_.org.mockito.ArgumentMatchers.any())
       }
     """
     } else
-      c.Expr[AnyMatcher[T]](q"new org.mockito.matchers.AnyMatcherStandard[$tpe]")
+      c.Expr[AnyMatcher[T]](q"new _root_.org.mockito.matchers.AnyMatcherStandard[$tpe]")
 
     if (c.settings.contains("mockito-print-matcher")) println(show(r.tree))
     r


### PR DESCRIPTION
Fix an issue that arose when some val/var in scope was named `org`