### PR TITLE
ByName fix

### DIFF
--- a/macro/src/main/scala/org/mockito/DoSomethingMacro.scala
+++ b/macro/src/main/scala/org/mockito/DoSomethingMacro.scala
@@ -14,8 +14,11 @@ object DoSomethingMacro {
     val r = c.Expr[T] {
       c.macroApplication match {
         case q"$_.DoSomethingOps[$r]($v).willBe($_.returned).by[$_]($obj.$method[..$targs](...$args))" =>
+          if (args.exists(a => hasMatchers(c)(a))) {
           val newArgs = args.map(a => transformArgs(c)(a))
           q"_root_.org.mockito.MockitoSugar.doReturn[$r]($v).when($obj).$method[..$targs](...$newArgs)"
+          } else
+            q"_root_.org.mockito.MockitoSugar.doReturn[$r]($v).when($obj).$method[..$targs](...$args)"
 
         case q"$_.DoSomethingOps[$r]($v).willBe($_.returned).by[$_]($obj.$method[..$targs])" =>
           q"_root_.org.mockito.MockitoSugar.doReturn[$r]($v).when($obj).$method[..$targs]"
@@ -33,8 +36,11 @@ object DoSomethingMacro {
     val r = c.Expr[T] {
       c.macroApplication match {
         case q"$_.DoSomethingOps[$r]($v).willBe($_.answered).by[$_]($obj.$method[..$targs](...$args))" =>
+          if (args.exists(a => hasMatchers(c)(a))) {
           val newArgs = args.map(a => transformArgs(c)(a))
           q"_root_.org.mockito.MockitoSugar.doAnswer($v).when($obj).$method[..$targs](...$newArgs)"
+          } else
+            q"_root_.org.mockito.MockitoSugar.doAnswer($v).when($obj).$method[..$targs](...$args)"
 
         case q"$_.DoSomethingOps[$r]($v).willBe($_.answered).by[$_]($obj.$method[..$targs])" =>
           q"_root_.org.mockito.MockitoSugar.doAnswer($v).when($obj).$method[..$targs]"
@@ -52,8 +58,11 @@ object DoSomethingMacro {
     val r = c.Expr[T] {
       c.macroApplication match {
         case q"$_.ThrowSomethingOps[$_]($v).willBe($_.thrown).by[$_]($obj.$method[..$targs](...$args))" =>
+          if (args.exists(a => hasMatchers(c)(a))) {
           val newArgs = args.map(a => transformArgs(c)(a))
           q"_root_.org.mockito.MockitoSugar.doThrow($v).when($obj).$method[..$targs](...$newArgs)"
+          } else
+            q"_root_.org.mockito.MockitoSugar.doThrow($v).when($obj).$method[..$targs](...$args)"
 
         case q"$_.ThrowSomethingOps[$_]($v).willBe($_.thrown).by[$_]($obj.$method[..$targs])" =>
           q"_root_.org.mockito.MockitoSugar.doThrow($v).when($obj).$method[..$targs]"
@@ -71,8 +80,11 @@ object DoSomethingMacro {
     val r = c.Expr[T] {
       c.macroApplication match {
         case q"$_.theRealMethod.willBe($_.called).by[$_]($obj.$method[..$targs](...$args))" =>
+          if (args.exists(a => hasMatchers(c)(a))) {
           val newArgs = args.map(a => transformArgs(c)(a))
           q"_root_.org.mockito.MockitoSugar.doCallRealMethod.when($obj).$method[..$targs](...$newArgs)"
+          } else
+            q"_root_.org.mockito.MockitoSugar.doCallRealMethod.when($obj).$method[..$targs](...$args)"
 
         case q"$_.theRealMethod.willBe($_.called).by[$_]($obj.$method[..$targs])" =>
           q"_root_.org.mockito.MockitoSugar.doCallRealMethod.when($obj).$method[..$targs]"

--- a/macro/src/main/scala/org/mockito/Utils.scala
+++ b/macro/src/main/scala/org/mockito/Utils.scala
@@ -2,6 +2,8 @@ package org.mockito
 import scala.reflect.macros.blackbox
 
 object Utils {
+  private[mockito] def hasMatchers(c: blackbox.Context)(args: List[c.Tree]): Boolean =
+    args.exists(arg => isMatcher(c)(arg))
 
   private[mockito] def isMatcher(c: blackbox.Context)(arg: c.Tree): Boolean = {
     import c.universe._

--- a/macro/src/main/scala/org/mockito/VerifyMacro.scala
+++ b/macro/src/main/scala/org/mockito/VerifyMacro.scala
@@ -19,8 +19,11 @@ object VerifyMacro {
     val r = c.Expr[Unit] {
       c.macroApplication match {
         case q"$_.StubbingOps[$_]($obj.$method[..$targs](...$args)).was($_.called)($order)" =>
+          if (args.exists(a => hasMatchers(c)(a))) {
           val newArgs = args.map(a => transformArgs(c)(a))
           q"$order.verify($obj).$method[..$targs](...$newArgs)"
+          } else
+            q"$order.verify($obj).$method[..$targs](...$args)"
 
         case q"$_.StubbingOps[$_]($obj.$method[..$targs]).was($_.called)($order)" =>
           q"$order.verify($obj).$method[..$targs]"
@@ -41,8 +44,11 @@ object VerifyMacro {
           q"_root_.org.mockito.MockitoSugar.verifyZeroInteractions($obj)"
 
         case q"$_.StubbingOps[$_]($obj.$method[..$targs](...$args)).wasNever($_.called)($order)" =>
+          if (args.exists(a => hasMatchers(c)(a))) {
           val newArgs = args.map(a => transformArgs(c)(a))
           q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.never).$method[..$targs](...$newArgs)"
+          } else
+            q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.never).$method[..$targs](...$args)"
 
         case q"$_.StubbingOps[$_]($obj.$method[..$targs]).wasNever($_.called)($order)" =>
           q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.never).$method[..$targs]"
@@ -65,8 +71,11 @@ object VerifyMacro {
     val r = c.Expr[Unit] {
       c.macroApplication match {
         case q"$_.StubbingOps[$_]($obj.$method[..$targs](...$args)).wasCalled($times)($order)" =>
+          if (args.exists(a => hasMatchers(c)(a))) {
           val newArgs = args.map(a => transformArgs(c)(a))
           q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.times($times.times)).$method[..$targs](...$newArgs)"
+          } else
+            q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.times($times.times)).$method[..$targs](...$args)"
 
         case q"$_.StubbingOps[$_]($obj.$method[..$targs]).wasCalled($times)($order)" =>
           q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.times($times.times)).$method[..$targs]"
@@ -86,8 +95,11 @@ object VerifyMacro {
     val r = c.Expr[Unit] {
       c.macroApplication match {
         case q"$_.StubbingOps[$_]($obj.$method[..$targs](...$args)).wasCalled($times)($order)" =>
+          if (args.exists(a => hasMatchers(c)(a))) {
           val newArgs = args.map(a => transformArgs(c)(a))
           q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.atLeast($times.times)).$method[..$targs](...$newArgs)"
+          } else
+            q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.atLeast($times.times)).$method[..$targs](...$args)"
 
         case q"$_.StubbingOps[$_]($obj.$method[..$targs]).wasCalled($times)($order)" =>
           q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.atLeast($times.times)).$method[..$targs]"
@@ -107,8 +119,11 @@ object VerifyMacro {
     val r = c.Expr[Unit] {
       c.macroApplication match {
         case q"$_.StubbingOps[$_]($obj.$method[..$targs](...$args)).wasCalled($times)($order)" =>
+          if (args.exists(a => hasMatchers(c)(a))) {
           val newArgs = args.map(a => transformArgs(c)(a))
           q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.atMost($times.times)).$method[..$targs](...$newArgs)"
+          } else
+            q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.atMost($times.times)).$method[..$targs](...$args)"
 
         case q"$_.StubbingOps[$_]($obj.$method[..$targs]).wasCalled($times)($order)" =>
           q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.atMost($times.times)).$method[..$targs]"
@@ -128,8 +143,11 @@ object VerifyMacro {
     val r = c.Expr[Unit] {
       c.macroApplication match {
         case q"$_.StubbingOps[$_]($obj.$method[..$targs](...$args)).wasCalled($_)($order)" =>
+          if (args.exists(a => hasMatchers(c)(a))) {
           val newArgs = args.map(a => transformArgs(c)(a))
           q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.only).$method[..$targs](...$newArgs)"
+          } else
+            q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.only).$method[..$targs](...$args)"
 
         case q"$_.StubbingOps[$_]($obj.$method[..$targs]).wasCalled($_)($order)" =>
           q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.only).$method[..$targs]"

--- a/macro/src/main/scala/org/mockito/WhenMacro.scala
+++ b/macro/src/main/scala/org/mockito/WhenMacro.scala
@@ -19,8 +19,11 @@ object WhenMacro {
     val r = c.Expr[ReturnActions[T]] {
       c.macroApplication match {
         case q"$_.StubbingOps[$t]($obj.$method[..$targs](...$args)).shouldReturn" =>
+          if (args.exists(a => hasMatchers(c)(a))) {
           val newArgs = args.map(a => transformArgs(c)(a))
           q"new _root_.org.mockito.WhenMacro.ReturnActions(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$newArgs)))"
+          } else
+            q"new _root_.org.mockito.WhenMacro.ReturnActions(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$args)))"
 
         case q"$_.StubbingOps[$t]($obj.$method[..$targs]).shouldReturn" =>
           q"new _root_.org.mockito.WhenMacro.ReturnActions(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs]))"
@@ -38,8 +41,11 @@ object WhenMacro {
     val r = c.Expr[Unit] {
       c.macroApplication match {
         case q"$_.StubbingOps[$t]($obj.$method[..$targs](...$args)).isLenient()" =>
+          if (args.exists(a => hasMatchers(c)(a))) {
           val newArgs = args.map(a => transformArgs(c)(a))
           q"new _root_.org.mockito.stubbing.ScalaFirstStubbing(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$newArgs))).isLenient()"
+          } else
+            q"new _root_.org.mockito.stubbing.ScalaFirstStubbing(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$args))).isLenient()"
 
         case q"$_.StubbingOps[$t]($obj.$method[..$targs]).isLenient()" =>
           q"new _root_.org.mockito.stubbing.ScalaFirstStubbing(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs])).isLenient()"
@@ -59,8 +65,11 @@ object WhenMacro {
     val r = c.Expr[ScalaOngoingStubbing[T]] {
       c.macroApplication match {
         case q"$_.StubbingOps[$t]($obj.$method[..$targs](...$args)).shouldCall($_.realMethod)" =>
+          if (args.exists(a => hasMatchers(c)(a))) {
           val newArgs = args.map(a => transformArgs(c)(a))
           q"new _root_.org.mockito.stubbing.ScalaOngoingStubbing(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$newArgs)).thenCallRealMethod())"
+          } else
+            q"new _root_.org.mockito.stubbing.ScalaOngoingStubbing(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$args)).thenCallRealMethod())"
 
         case q"$_.StubbingOps[$t]($obj.$method[..$targs]).shouldCall($_.realMethod)" =>
           q"new _root_.org.mockito.stubbing.ScalaOngoingStubbing(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs]).thenCallRealMethod())"
@@ -82,8 +91,11 @@ object WhenMacro {
     val r = c.Expr[ThrowActions[T]] {
       c.macroApplication match {
         case q"$_.StubbingOps[$t]($obj.$method[..$targs](...$args)).shouldThrow" =>
+          if (args.exists(a => hasMatchers(c)(a))) {
           val newArgs = args.map(a => transformArgs(c)(a))
           q"new _root_.org.mockito.WhenMacro.ThrowActions(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$newArgs)))"
+          } else
+            q"new _root_.org.mockito.WhenMacro.ThrowActions(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$args)))"
 
         case q"$_.StubbingOps[$t]($obj.$method[..$targs]).shouldThrow" =>
           q"new _root_.org.mockito.WhenMacro.ThrowActions(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs]))"
@@ -127,8 +139,11 @@ object WhenMacro {
     val r = c.Expr[AnswerActions[T]] {
       c.macroApplication match {
         case q"$_.StubbingOps[$t]($obj.$method[..$targs](...$args)).shouldAnswer" =>
+          if (args.exists(a => hasMatchers(c)(a))) {
           val newArgs = args.map(a => transformArgs(c)(a))
           q"new _root_.org.mockito.WhenMacro.AnswerActions(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$newArgs)))"
+          } else
+            q"new _root_.org.mockito.WhenMacro.AnswerActions(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs](...$args)))"
 
         case q"$_.StubbingOps[$t]($obj.$method[..$targs]).shouldAnswer" =>
           q"new _root_.org.mockito.WhenMacro.AnswerActions(_root_.org.mockito.Mockito.when[$t]($obj.$method[..$targs]))"


### PR DESCRIPTION
Restore idiomatic syntax to wrap arguments in eqTo only if any matcher has already been used in that stub.

This allows stubbing byName parameters with raw values