### PR TITLE
Resolve warn-value-discard for wasCalled

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,7 @@ lazy val commonSettings =
       "-language:reflectiveCalls",
 //      "-Xmacro-settings:mockito-print-when,mockito-print-do-something,mockito-print-verify,mockito-print-captor,mockito-print-matcher,mockito-print-extractor"
     ),
+    Test / scalacOptions ++= Seq("-Ywarn-value-discard")
   )
 
 lazy val commonLibraries = Seq(

--- a/common/src/main/scala/org/mockito/MockitoAPI.scala
+++ b/common/src/main/scala/org/mockito/MockitoAPI.scala
@@ -349,7 +349,15 @@ private[mockito] trait Rest extends MockitoEnhancer with DoSomething with Verifi
   /**
    * Delegates to <code>Mockito.verifyZeroInteractions()</code>, it's only here to expose the full Mockito API
    */
-  def verifyZeroInteractions(mocks: AnyRef*): Unit = Mockito.verifyZeroInteractions(mocks: _*)
+  def verifyZeroInteractions[T](mock: T): T = {
+    Mockito.verifyZeroInteractions(mock.asInstanceOf[AnyRef])
+    mock
+  }
+
+  def verifyZeroInteractions(firstMock: AnyRef, secondMock: AnyRef, restOfMocks: AnyRef*): Unit = {
+    val mocks = Seq(firstMock, secondMock) ++ restOfMocks
+    Mockito.verifyZeroInteractions(mocks: _*)
+  }
 
   /**
    * Delegates to <code>Mockito.inOrder()</code>, it's only here to expose the full Mockito API

--- a/common/src/main/scala/org/mockito/MockitoAPI.scala
+++ b/common/src/main/scala/org/mockito/MockitoAPI.scala
@@ -349,15 +349,7 @@ private[mockito] trait Rest extends MockitoEnhancer with DoSomething with Verifi
   /**
    * Delegates to <code>Mockito.verifyZeroInteractions()</code>, it's only here to expose the full Mockito API
    */
-  def verifyZeroInteractions[T](mock: T): T = {
-    Mockito.verifyZeroInteractions(mock.asInstanceOf[AnyRef])
-    mock
-  }
-
-  def verifyZeroInteractions(firstMock: AnyRef, secondMock: AnyRef, restOfMocks: AnyRef*): Unit = {
-    val mocks = Seq(firstMock, secondMock) ++ restOfMocks
-    Mockito.verifyZeroInteractions(mocks: _*)
-  }
+  def verifyZeroInteractions(mocks: AnyRef*): AnyRef = Mockito.verifyZeroInteractions(mocks: _*).asInstanceOf[AnyRef]
 
   /**
    * Delegates to <code>Mockito.inOrder()</code>, it's only here to expose the full Mockito API

--- a/common/src/main/scala/org/mockito/MockitoAPI.scala
+++ b/common/src/main/scala/org/mockito/MockitoAPI.scala
@@ -349,7 +349,7 @@ private[mockito] trait Rest extends MockitoEnhancer with DoSomething with Verifi
   /**
    * Delegates to <code>Mockito.verifyZeroInteractions()</code>, it's only here to expose the full Mockito API
    */
-  def verifyZeroInteractions(mocks: AnyRef*): AnyRef = Mockito.verifyZeroInteractions(mocks: _*).asInstanceOf[AnyRef]
+  def verifyZeroInteractions(mocks: AnyRef*): Unit = Mockito.verifyZeroInteractions(mocks: _*)
 
   /**
    * Delegates to <code>Mockito.inOrder()</code>, it's only here to expose the full Mockito API

--- a/core/src/main/scala/org/mockito/IdiomaticMockito.scala
+++ b/core/src/main/scala/org/mockito/IdiomaticMockito.scala
@@ -38,7 +38,7 @@ trait IdiomaticMockito extends MockCreator {
 
     def was(called: Called.type)(implicit order: VerifyOrder): T = macro VerifyMacro.wasMacro[T]
 
-    def wasNever(called: Called.type)(implicit order: VerifyOrder): AnyRef = macro VerifyMacro.wasNotMacro[AnyRef]
+    def wasNever(called: Called.type)(implicit order: VerifyOrder): T = macro VerifyMacro.wasNotMacro[T]
 
     def wasNever(called: CalledAgain)(implicit $ev: T <:< AnyRef): Unit = verifyNoMoreInteractions(stubbing.asInstanceOf[AnyRef])
 
@@ -133,7 +133,7 @@ trait IdiomaticMockito extends MockCreator {
   val atMostTenTimes    = AtMost(10)
 
   object InOrder {
-    def apply(mocks: AnyRef*)(verifications: VerifyInOrder => AnyRef): AnyRef = verifications(VerifyInOrder(mocks))
+    def apply[T](mocks: AnyRef*)(verifications: VerifyInOrder => T): T = verifications(VerifyInOrder(mocks))
   }
 
   def atLeast(t: Times): AtLeast = AtLeast(t.times)

--- a/core/src/main/scala/org/mockito/IdiomaticMockito.scala
+++ b/core/src/main/scala/org/mockito/IdiomaticMockito.scala
@@ -38,7 +38,7 @@ trait IdiomaticMockito extends MockCreator {
 
     def was(called: Called.type)(implicit order: VerifyOrder): T = macro VerifyMacro.wasMacro[T]
 
-    def wasNever(called: Called.type)(implicit order: VerifyOrder): Unit = macro VerifyMacro.wasNotMacro[T]
+    def wasNever(called: Called.type)(implicit order: VerifyOrder): T = macro VerifyMacro.wasNotMacro[T]
 
     def wasNever(called: CalledAgain)(implicit $ev: T <:< AnyRef): Unit = verifyNoMoreInteractions(stubbing.asInstanceOf[AnyRef])
 
@@ -133,7 +133,7 @@ trait IdiomaticMockito extends MockCreator {
   val atMostTenTimes    = AtMost(10)
 
   object InOrder {
-    def apply(mocks: AnyRef*)(verifications: VerifyInOrder => Unit): Unit = verifications(VerifyInOrder(mocks))
+    def apply(mocks: AnyRef*)(verifications: VerifyInOrder => AnyRef): AnyRef = verifications(VerifyInOrder(mocks))
   }
 
   def atLeast(t: Times): AtLeast = AtLeast(t.times)

--- a/core/src/main/scala/org/mockito/IdiomaticMockito.scala
+++ b/core/src/main/scala/org/mockito/IdiomaticMockito.scala
@@ -36,19 +36,19 @@ trait IdiomaticMockito extends MockCreator {
 
     def shouldAnswer: AnswerActions[T] = macro WhenMacro.shouldAnswer[T]
 
-    def was(called: Called.type)(implicit order: VerifyOrder): Unit = macro VerifyMacro.wasMacro[T]
+    def was(called: Called.type)(implicit order: VerifyOrder): T = macro VerifyMacro.wasMacro[T]
 
     def wasNever(called: Called.type)(implicit order: VerifyOrder): Unit = macro VerifyMacro.wasNotMacro[T]
 
     def wasNever(called: CalledAgain)(implicit $ev: T <:< AnyRef): Unit = verifyNoMoreInteractions(stubbing.asInstanceOf[AnyRef])
 
-    def wasCalled(t: Times)(implicit order: VerifyOrder): Unit = macro VerifyMacro.wasMacroTimes[T]
+    def wasCalled(t: Times)(implicit order: VerifyOrder): T = macro VerifyMacro.wasMacroTimes[T]
 
-    def wasCalled(t: AtLeast)(implicit order: VerifyOrder): Unit = macro VerifyMacro.wasMacroAtLeast[T]
+    def wasCalled(t: AtLeast)(implicit order: VerifyOrder): T = macro VerifyMacro.wasMacroAtLeast[T]
 
-    def wasCalled(t: AtMost)(implicit order: VerifyOrder): Unit = macro VerifyMacro.wasMacroAtMost[T]
+    def wasCalled(t: AtMost)(implicit order: VerifyOrder): T = macro VerifyMacro.wasMacroAtMost[T]
 
-    def wasCalled(t: OnlyOn)(implicit order: VerifyOrder): Unit = macro VerifyMacro.wasMacroOnlyOn[T]
+    def wasCalled(t: OnlyOn)(implicit order: VerifyOrder): T = macro VerifyMacro.wasMacroOnlyOn[T]
 
     //noinspection AccessorLikeMethodIsUnit
     def isLenient(): Unit = macro WhenMacro.isLenient[T]

--- a/core/src/main/scala/org/mockito/IdiomaticMockito.scala
+++ b/core/src/main/scala/org/mockito/IdiomaticMockito.scala
@@ -38,7 +38,7 @@ trait IdiomaticMockito extends MockCreator {
 
     def was(called: Called.type)(implicit order: VerifyOrder): T = macro VerifyMacro.wasMacro[T]
 
-    def wasNever(called: Called.type)(implicit order: VerifyOrder): T = macro VerifyMacro.wasNotMacro[T]
+    def wasNever(called: Called.type)(implicit order: VerifyOrder): AnyRef = macro VerifyMacro.wasNotMacro[AnyRef]
 
     def wasNever(called: CalledAgain)(implicit $ev: T <:< AnyRef): Unit = verifyNoMoreInteractions(stubbing.asInstanceOf[AnyRef])
 

--- a/core/src/test/scala/user/org/mockito/integrations/scalatest/ResetMocksAfterEachTestTest.scala
+++ b/core/src/test/scala/user/org/mockito/integrations/scalatest/ResetMocksAfterEachTestTest.scala
@@ -10,7 +10,12 @@ class ResetMocksAfterEachTestTest extends WordSpec with MockitoSugar with ResetM
     def bar(a: String) = "bar"
   }
 
+  trait Baz {
+    def qux(a: String) = "qux"
+  }
+
   val foo = mock[Foo]
+  val baz = mock[Baz]
 
   "ResetMocksAfterEachTest" should {
 
@@ -31,6 +36,30 @@ class ResetMocksAfterEachTestTest extends WordSpec with MockitoSugar with ResetM
       when(foo.bar("pepe")) thenReturn "mocked2"
 
       foo.bar("pepe") shouldBe "mocked2"
+
+    }
+
+    "have clean state for all mocks test 1" in {
+
+      verifyZeroInteractions(foo, baz)
+
+      when(foo.bar("pepe")) thenReturn "mocked3"
+      when(baz.qux("epep")) thenReturn "mocked4"
+
+      foo.bar("pepe") shouldBe "mocked3"
+      baz.qux("epep") shouldBe "mocked4"
+
+    }
+
+    "have clean state for all mocks test 2" in {
+
+      verifyZeroInteractions(foo, baz)
+
+      when(foo.bar("pepe")) thenReturn "mocked5"
+      when(baz.qux("epep")) thenReturn "mocked6"
+
+      foo.bar("pepe") shouldBe "mocked5"
+      baz.qux("epep") shouldBe "mocked6"
 
     }
 

--- a/macro/src/main/scala/org/mockito/VerifyMacro.scala
+++ b/macro/src/main/scala/org/mockito/VerifyMacro.scala
@@ -35,10 +35,10 @@ object VerifyMacro {
     r
   }
 
-  def wasNotMacro[T: c.WeakTypeTag](c: blackbox.Context)(called: c.Expr[Called.type])(order: c.Expr[VerifyOrder]): c.Expr[T] = {
+  def wasNotMacro[T: c.WeakTypeTag](c: blackbox.Context)(called: c.Expr[Called.type])(order: c.Expr[VerifyOrder]): c.Expr[AnyRef] = {
     import c.universe._
 
-    val r = c.Expr[T] {
+    val r = c.Expr[AnyRef] {
       c.macroApplication match {
         case q"$_.StubbingOps[$_]($_.this.$obj).wasNever($_.called)($_)" =>
           q"_root_.org.mockito.MockitoSugar.verifyZeroInteractions($obj)"

--- a/macro/src/main/scala/org/mockito/VerifyMacro.scala
+++ b/macro/src/main/scala/org/mockito/VerifyMacro.scala
@@ -35,10 +35,10 @@ object VerifyMacro {
     r
   }
 
-  def wasNotMacro[T: c.WeakTypeTag](c: blackbox.Context)(called: c.Expr[Called.type])(order: c.Expr[VerifyOrder]): c.Expr[AnyRef] = {
+  def wasNotMacro[T: c.WeakTypeTag](c: blackbox.Context)(called: c.Expr[Called.type])(order: c.Expr[VerifyOrder]): c.Expr[T] = {
     import c.universe._
 
-    val r = c.Expr[AnyRef] {
+    val r = c.Expr[T] {
       c.macroApplication match {
         case q"$_.StubbingOps[$_]($_.this.$obj).wasNever($_.called)($_)" =>
           q"_root_.org.mockito.MockitoSugar.verifyZeroInteractions($obj); null;"

--- a/macro/src/main/scala/org/mockito/VerifyMacro.scala
+++ b/macro/src/main/scala/org/mockito/VerifyMacro.scala
@@ -41,7 +41,7 @@ object VerifyMacro {
     val r = c.Expr[AnyRef] {
       c.macroApplication match {
         case q"$_.StubbingOps[$_]($_.this.$obj).wasNever($_.called)($_)" =>
-          q"_root_.org.mockito.MockitoSugar.verifyZeroInteractions($obj)"
+          q"_root_.org.mockito.MockitoSugar.verifyZeroInteractions($obj); null;"
 
         case q"$_.StubbingOps[$_]($obj.$method[..$targs](...$args)).wasNever($_.called)($order)" =>
           if (args.exists(a => hasMatchers(c)(a))) {
@@ -54,7 +54,7 @@ object VerifyMacro {
           q"$order.verifyWithMode($obj, _root_.org.mockito.Mockito.never).$method[..$targs]"
 
         case q"$_.StubbingOps[$_]($obj).wasNever($_.called)($_)" =>
-          q"_root_.org.mockito.MockitoSugar.verifyZeroInteractions($obj)"
+          q"_root_.org.mockito.MockitoSugar.verifyZeroInteractions($obj); null;"
 
         case o => throw new Exception(s"Couldn't recognize ${show(o)}")
       }

--- a/macro/src/main/scala/org/mockito/VerifyMacro.scala
+++ b/macro/src/main/scala/org/mockito/VerifyMacro.scala
@@ -13,10 +13,10 @@ object Called {
 
 object VerifyMacro {
 
-  def wasMacro[T: c.WeakTypeTag](c: blackbox.Context)(called: c.Expr[Called.type])(order: c.Expr[VerifyOrder]): c.Expr[Unit] = {
+  def wasMacro[T: c.WeakTypeTag](c: blackbox.Context)(called: c.Expr[Called.type])(order: c.Expr[VerifyOrder]): c.Expr[T] = {
     import c.universe._
 
-    val r = c.Expr[Unit] {
+    val r = c.Expr[T] {
       c.macroApplication match {
         case q"$_.StubbingOps[$_]($obj.$method[..$targs](...$args)).was($_.called)($order)" =>
           if (args.exists(a => hasMatchers(c)(a))) {
@@ -65,10 +65,10 @@ object VerifyMacro {
 
   case class Times(times: Int)
 
-  def wasMacroTimes[T: c.WeakTypeTag](c: blackbox.Context)(t: c.Expr[Times])(order: c.Expr[VerifyOrder]): c.Expr[Unit] = {
+  def wasMacroTimes[T: c.WeakTypeTag](c: blackbox.Context)(t: c.Expr[Times])(order: c.Expr[VerifyOrder]): c.Expr[T] = {
     import c.universe._
 
-    val r = c.Expr[Unit] {
+    val r = c.Expr[T] {
       c.macroApplication match {
         case q"$_.StubbingOps[$_]($obj.$method[..$targs](...$args)).wasCalled($times)($order)" =>
           if (args.exists(a => hasMatchers(c)(a))) {
@@ -89,10 +89,10 @@ object VerifyMacro {
 
   case class AtLeast(times: Int)
 
-  def wasMacroAtLeast[T: c.WeakTypeTag](c: blackbox.Context)(t: c.Expr[AtLeast])(order: c.Expr[VerifyOrder]): c.Expr[Unit] = {
+  def wasMacroAtLeast[T: c.WeakTypeTag](c: blackbox.Context)(t: c.Expr[AtLeast])(order: c.Expr[VerifyOrder]): c.Expr[T] = {
     import c.universe._
 
-    val r = c.Expr[Unit] {
+    val r = c.Expr[T] {
       c.macroApplication match {
         case q"$_.StubbingOps[$_]($obj.$method[..$targs](...$args)).wasCalled($times)($order)" =>
           if (args.exists(a => hasMatchers(c)(a))) {
@@ -113,10 +113,10 @@ object VerifyMacro {
 
   case class AtMost(times: Int)
 
-  def wasMacroAtMost[T: c.WeakTypeTag](c: blackbox.Context)(t: c.Expr[AtMost])(order: c.Expr[VerifyOrder]): c.Expr[Unit] = {
+  def wasMacroAtMost[T: c.WeakTypeTag](c: blackbox.Context)(t: c.Expr[AtMost])(order: c.Expr[VerifyOrder]): c.Expr[T] = {
     import c.universe._
 
-    val r = c.Expr[Unit] {
+    val r = c.Expr[T] {
       c.macroApplication match {
         case q"$_.StubbingOps[$_]($obj.$method[..$targs](...$args)).wasCalled($times)($order)" =>
           if (args.exists(a => hasMatchers(c)(a))) {
@@ -137,10 +137,10 @@ object VerifyMacro {
 
   class OnlyOn
 
-  def wasMacroOnlyOn[T: c.WeakTypeTag](c: blackbox.Context)(t: c.Expr[OnlyOn])(order: c.Expr[VerifyOrder]): c.Expr[Unit] = {
+  def wasMacroOnlyOn[T: c.WeakTypeTag](c: blackbox.Context)(t: c.Expr[OnlyOn])(order: c.Expr[VerifyOrder]): c.Expr[T] = {
     import c.universe._
 
-    val r = c.Expr[Unit] {
+    val r = c.Expr[T] {
       c.macroApplication match {
         case q"$_.StubbingOps[$_]($obj.$method[..$targs](...$args)).wasCalled($_)($order)" =>
           if (args.exists(a => hasMatchers(c)(a))) {

--- a/macro/src/main/scala/org/mockito/VerifyMacro.scala
+++ b/macro/src/main/scala/org/mockito/VerifyMacro.scala
@@ -35,10 +35,10 @@ object VerifyMacro {
     r
   }
 
-  def wasNotMacro[T: c.WeakTypeTag](c: blackbox.Context)(called: c.Expr[Called.type])(order: c.Expr[VerifyOrder]): c.Expr[Unit] = {
+  def wasNotMacro[T: c.WeakTypeTag](c: blackbox.Context)(called: c.Expr[Called.type])(order: c.Expr[VerifyOrder]): c.Expr[T] = {
     import c.universe._
 
-    val r = c.Expr[Unit] {
+    val r = c.Expr[T] {
       c.macroApplication match {
         case q"$_.StubbingOps[$_]($_.this.$obj).wasNever($_.called)($_)" =>
           q"_root_.org.mockito.MockitoSugar.verifyZeroInteractions($obj)"


### PR DESCRIPTION
This PR attempts to resolve the following [issue raised in SO](https://stackoverflow.com/q/55305006/5205022): 

Say we have

```
def load(): DataFrame
```

and we set compiler flag

`scalacOptions += "-Ywarn-value-discard"`

then

```
obj.load() wasCalled once
```

raises warning

```
discarded non-Unit value
```