### PR TITLE
Updated broken links for tests in scala-mockito.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ The library has independent developers, release cycle and versioning from core m
 
 ### Please ensure you don't declare `mockito-core` as a dependency. `mockito-scala` will pull the appropiate version automatically
 
-### Note: For more examples and use cases than the ones shown below, please refer to the library's [tests](/core/src/test)
+### Note: For more examples and use cases than the ones shown below, please refer to the library's specific tests
+- [Cats](/cats/src/test)
+- [ScalaTest](/scalatest/src/test)
+- [Specs2](/specs2/src/test)
+- [Scalaz](/scalaz/src/test)
 
 ## Notes for v1.4.0
 As Specs2 support was added, now the library has been split in 3 different artifacts


### PR DESCRIPTION
Example of links for tests using scala-mockito for Cats, ScalaTest, Scalaz and Specs2 were broken.