### PR TITLE
Close mocking session on aborted Scalatest runs

### DIFF
--- a/core/src/main/scala/org/mockito/MockitoScalaSession.scala
+++ b/core/src/main/scala/org/mockito/MockitoScalaSession.scala
@@ -20,6 +20,12 @@ class MockitoScalaSession(name: String, strictness: Strictness, logger: MockitoS
 
   Mockito.framework().addListener(listener)
 
+  /**
+   * If the test has thrown an exception, the session will check first if the exception could be related to a misuse
+   * of mockito. If not, it will rethrow the original error so the real test failure can be reported by the testing framework
+   *
+   * @param t exception thrown by the test framework
+   */
   def finishMocking(t: Option[Throwable] = None): Unit = {
     listener.cleanLenientStubs()
     try t.fold {

--- a/scalatest/src/main/scala/org/mockito/scalatest/MockitoSessionFixture.scala
+++ b/scalatest/src/main/scala/org/mockito/scalatest/MockitoSessionFixture.scala
@@ -1,8 +1,7 @@
 package org.mockito.scalatest
+
 import org.mockito.{ MockitoScalaSession, Strictness }
 import org.scalatest._
-
-import scala.util.control.NonFatal
 
 private[mockito] trait MockitoSessionFixture extends TestSuite { this: Suite =>
 
@@ -11,8 +10,6 @@ private[mockito] trait MockitoSessionFixture extends TestSuite { this: Suite =>
   abstract override def withFixture(test: NoArgTest): Outcome = {
     val session = MockitoScalaSession(name = s"${test.name} - session", strictness)
 
-    // if the test has thrown an exception, the session will check first if the exception could be related to a mis-use
-    // of mockito, if not, it will throw nothing so the real test failure can be reported by the ScalaTest
     val result =
       try {
         super.withFixture(test)
@@ -34,15 +31,13 @@ private[mockito] trait MockitoSessionAsyncFixture extends AsyncTestSuite { this:
   abstract override def withFixture(test: NoArgAsyncTest): FutureOutcome = {
     val session = MockitoScalaSession(name = s"${test.name} - session", strictness)
 
-    // if the test has thrown an exception, the session will check first if the exception could be related to a mis-use
-    // of mockito, if not, it will throw nothing so the real test failure can be reported by the ScalaTest
     val result =
       try {
         super.withFixture(test)
       } catch {
-        case ex: Throwable =>
-          session.finishMocking(Some(ex))
-          throw ex
+        case t: Throwable =>
+          session.finishMocking(Some(t))
+          throw t
       }
 
     result.onOutcomeThen(o => session.finishMocking(o.toOption))


### PR DESCRIPTION
Fixes #211 .

A Scalatest test case run (`super.withFixture(test)`) will actually throw an exception when the entire test suite must be aborted (ie initialization errors or just non-`Exception` errors such as `StackOverflowError`). In such a case, the current open mocking session is never closed, and all subsequent test suites using the same base class start to fail because Mockito does not allow creating a new session when there's an unclosed one.
We can fix it by catching all throwables, trying to close the session and rethrow.  