### PR TITLE
Introduce "expect (...) ON x" to be used instead of "expect (...) TO x" on mock objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,19 @@ The library has independent developers, release cycle and versioning from core m
 - [Scalaz](/scalaz/src/test)
 
 ## Partial unification
-If you're in Scala 2.11 or 2.12 you'll probably want to add the compiler flag "-Ypartial-unification", if you don't you risk some compile errors when trying to stub complex types using the idiomatic syntax
+If you're in Scala 2.11 or 2.12 you'll probably want to add the compiler flag `-Ypartial-unification`, if you don't you risk some compile errors when trying to stub complex types using the idiomatic syntax
+
+## Notes for 1.13.6
+
+We slightly changed the way one would expect no/no more interactions with a mock object in Expectations DSL.
+From now on, `expect (...) to` should only be used on stubbed methods, and can't express expectations about interactions with the mock objects itself.
+
+In order to express expectations on a mock, one would use `expect (...) on` (note the use of `on` vs `to`) where such expectations are supported.
+
+* Instead of `expect no calls to aMock`, use `expect no calls on aMock`.
+* Instead of `expect noMore calls to aMock`, use `expect noMore calls on aMock`.
+
+Expectations about no _method_ calls stay the same: `expect no calls to aMock.bar(*)`.  
 
 ## Notes for 1.13.0
 
@@ -399,7 +411,8 @@ trait Foo {
   
 val aMock = mock[Foo]  
   
-verifyZeroInteractions(aMock)                     <=> expect no calls to aMock
+verifyZeroInteractions(aMock)                     <=> expect no calls on aMock
+
 verify(aMock).bar                                 <=> expect a call to aMock.bar
 verify(aMock).bar(any)                            <=> expect a call to aMock.bar(*)
 
@@ -423,7 +436,8 @@ verify(aMock, atMost(6)).bar                      <=> expect atMostSix calls to 
 verify(aMock, timeout(2000).times(2)).bar         <=> expect (2.calls within 2.seconds) to aMock.bar
 verify(aMock, timeout(2000).atLeast(6)).bar       <=> expect (atLeast(6.calls) within 2.seconds) to aMock.bar
 
-verifyNoMoreInteractions(aMock)                   <=> expect noMore calls to aMock
+verifyNoMoreInteractions(aMock)                   <=> expect noMore calls on aMock
+verifyNoMoreInteractions(ignoreStubs(aMock))      <=> expect noMore calls(ignoringStubs) on aMock
 
 val order = inOrder(mock1, mock2)                 <=> InOrder(mock1, mock2) { implicit order =>
 order.verify(mock2).someMethod()                  <=>   expect a call to mock2.someMethod()

--- a/core/src/main/scala/org/mockito/IdiomaticMockitoBase.scala
+++ b/core/src/main/scala/org/mockito/IdiomaticMockitoBase.scala
@@ -87,6 +87,8 @@ object IdiomaticMockitoBase {
   // types for postfix verifications
   object CallWord
   object CallsWord {
+    // No special logic here - the pattern "calls(ignoringStubs)" is detected by Expect macro
+    // and transformed into the right Mockito call
     def apply(ignoringStubsWord: IgnoringStubs.type): CallsWord.type = this
   }
 }

--- a/macro/src/main/scala/org/mockito/ExpectMacro.scala
+++ b/macro/src/main/scala/org/mockito/ExpectMacro.scala
@@ -25,11 +25,11 @@ object ExpectMacro extends VerificationMacroTransformer {
         q"""if (!_root_.org.mockito.MockitoSugar.mockingDetails($obj).isMock)
               throw new _root_.org.mockito.exceptions.misusing.MissingMethodInvocationException(Seq(
                 "'expect no calls to <?>' requires an argument which is 'a method call on a mock',",
-                "  but [" + $calledPattern + "] is a mock object.",
+                "  but looks like [" + $calledPattern + "] is not a method call on a mock. Is it a mock object?",
                 "",
                 "The following would be correct (note the usage of 'calls to' vs 'calls on'):",
-                "    expect no calls to " + $calledPattern + ".bar(*)",
-                "    expect no calls on " + $calledPattern,
+                "    expect no calls to aMock.bar(*)",
+                "    expect no calls on aMock",
                 ""
               ).mkString("\n"))
             else ${transformInvocation(c)(q"$obj.$methodOrField", order, q"${c.prefix}.mode")}

--- a/macro/src/main/scala/org/mockito/ExpectMacro.scala
+++ b/macro/src/main/scala/org/mockito/ExpectMacro.scala
@@ -4,12 +4,14 @@ import scala.reflect.macros.blackbox
 
 object ExpectMacro extends VerificationMacroTransformer {
 
-  def to[R](c: blackbox.Context)(invocationOnMock: c.Tree)(order: c.Expr[VerifyOrder]): c.Expr[R] = {
+  def callsTo[R](c: blackbox.Context)(stubbedMethodCall: c.Tree)(order: c.Expr[VerifyOrder]): c.Expr[R] = {
     import c.universe._
 
-    val r   = c.Expr[R](transformExpectation(c)(c.macroApplication))
-    val pos = s"${c.enclosingPosition.source.file.name}:${c.enclosingPosition.line}"
-    if (c.settings.contains("mockito-print-expect")) println(pos + " " + show(r.tree))
+    val r = c.Expr[R](transformExpectation(c)(c.macroApplication))
+    if (c.settings.contains("mockito-print-expect")) {
+      val pos = s"${c.enclosingPosition.source.file.name}:${c.enclosingPosition.line}"
+      println(pos + " " + show(r.tree))
+    }
 
     r
   }
@@ -18,22 +20,23 @@ object ExpectMacro extends VerificationMacroTransformer {
     import c.universe._
 
     called match {
-      case q"$_.this.expect.no($_.calls).to($_.this.$obj)($_)" =>
-        q"verification(_root_.org.mockito.MockitoSugar.verifyZeroInteractions($obj))"
-      case q"$_.this.expect.noMore($_.calls).to($_.this.$obj)($_)" =>
-        q"verification(_root_.org.mockito.MockitoSugar.verifyNoMoreInteractions($obj))"
-      case q"$_.expect.noMore($_.calls.apply($_.ignoringStubs)).to($_.this.$obj)($_)" =>
-        q"verification(_root_.org.mockito.MockitoSugar.verifyNoMoreInteractions(_root_.org.mockito.MockitoSugar.ignoreStubs($obj): _*))"
+      case q"$_.this.expect.no($_).to($obj.$methodOrField)($order)" =>
+        val calledPattern = show(q"$obj.$methodOrField")
+        q"""if (!_root_.org.mockito.MockitoSugar.mockingDetails($obj).isMock)
+              throw new _root_.org.mockito.exceptions.misusing.MissingMethodInvocationException(Seq(
+                "'expect no calls to <?>' requires an argument which is 'a method call on a mock',",
+                "  but [" + $calledPattern + "] is a mock object.",
+                "",
+                "The following would be correct (note the usage of 'calls to' vs 'calls on'):",
+                "    expect no calls to " + $calledPattern + ".bar(*)",
+                "    expect no calls on " + $calledPattern,
+                ""
+              ).mkString("\n"))
+            else ${transformInvocation(c)(q"$obj.$methodOrField", order, q"${c.prefix}.mode")}
+         """
 
       case q"$_.this.expect.$_($_).to($obj.$method[..$targs](...$args))($order)" =>
         transformInvocation(c)(q"$obj.$method[..$targs](...$args)", order, q"${c.prefix}.mode")
-
-      case q"$_.this.expect.no($_.calls).to($obj)($_)" =>
-        q"verification(_root_.org.mockito.MockitoSugar.verifyZeroInteractions($obj))"
-      case q"$_.this.expect.noMore($_.calls).to($obj)($_)" =>
-        q"verification(_root_.org.mockito.MockitoSugar.verifyNoMoreInteractions($obj))"
-      case q"$_.expect.noMore($_.calls.apply($_.ignoringStubs)).to($obj)($_)" =>
-        q"verification(_root_.org.mockito.MockitoSugar.verifyNoMoreInteractions(_root_.org.mockito.MockitoSugar.ignoreStubs($obj): _*))"
 
       case q"$_.this.expect.$_($_).to($call)($order)" =>
         transformInvocation(c)(call, order, q"${c.prefix}.mode")
@@ -41,7 +44,37 @@ object ExpectMacro extends VerificationMacroTransformer {
       case q"$_.expect($mode).to($call)($order)" =>
         transformInvocation(c)(call, order, mode)
 
-      case _ => throw new Exception(s"Expect macro: couldn't recognize invocation ${show(called)}")
+      case _ => throw new Exception(s"Expect-to macro: couldn't recognize invocation ${show(called)}")
     }
   }
+
+  def callsOn[R](c: blackbox.Context)(mock: c.Tree): c.Expr[R] = {
+    import c.universe._
+
+    val r = c.Expr[R](transformNoInteractionsExpectation(c)(c.macroApplication))
+    if (c.settings.contains("mockito-print-expect")) {
+      val pos = s"${c.enclosingPosition.source.file.name}:${c.enclosingPosition.line}"
+      println(pos + " " + show(r.tree))
+    }
+
+    r
+  }
+
+  def transformNoInteractionsExpectation[R](c: blackbox.Context)(called: c.Tree): c.Tree = {
+    import c.universe._
+
+    called match {
+      case q"$_.this.expect.no($_.calls).on($obj)" =>
+        q"verification(_root_.org.mockito.MockitoSugar.verifyZeroInteractions($obj))"
+
+      case q"$_.this.expect.noMore($_.calls).on($obj)" =>
+        q"verification(_root_.org.mockito.MockitoSugar.verifyNoMoreInteractions($obj))"
+
+      case q"$_.this.expect.noMore($_.calls.apply($_.ignoringStubs)).on($obj)" =>
+        q"verification(_root_.org.mockito.MockitoSugar.verifyNoMoreInteractions(_root_.org.mockito.MockitoSugar.ignoreStubs($obj): _*))"
+
+      case _ => throw new Exception(s"Expect-on macro: couldn't recognize invocation ${show(called)}")
+    }
+  }
+
 }

--- a/scalatest/src/test/scala/user/org/mockito/PrefixExpectationsTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/PrefixExpectationsTest.scala
@@ -75,11 +75,11 @@ class PrefixExpectationsTest extends AnyWordSpec with Matchers with ArgumentMatc
 
         exception.getMessage shouldBe
         """'expect no calls to <?>' requires an argument which is 'a method call on a mock',
-            |  but [fixture.org] is a mock object.
+            |  but looks like [fixture.org] is not a method call on a mock. Is it a mock object?
             |
             |The following would be correct (note the usage of 'calls to' vs 'calls on'):
-            |    expect no calls to fixture.org.bar(*)
-            |    expect no calls on fixture.org
+            |    expect no calls to aMock.bar(*)
+            |    expect no calls on aMock
             |""".stripMargin
       }
 

--- a/scalatest/src/test/scala/user/org/mockito/scalatest/IdiomaticMockitoFixtureClassTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/scalatest/IdiomaticMockitoFixtureClassTest.scala
@@ -41,6 +41,8 @@ class IdiomaticMockitoFixtureClassTest extends fixture.FlatSpec with IdiomaticMo
 
     a[NeverWantedButInvoked] should be thrownBy {
       f.foo.bar(*) wasNever called
+    }
+    a[NeverWantedButInvoked] should be thrownBy {
       f.foo.baz wasNever called
     }
   }

--- a/scalatest/src/test/scala/user/org/mockito/scalatest/IdiomaticMockitoWithExpectFixtureClassTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/scalatest/IdiomaticMockitoWithExpectFixtureClassTest.scala
@@ -31,6 +31,8 @@ class IdiomaticMockitoWithExpectFixtureClassTest extends fixture.FlatSpec with I
 
     a[NeverWantedButInvoked] should be thrownBy {
       expect no calls to f.foo.bar(*)
+    }
+    a[NeverWantedButInvoked] should be thrownBy {
       expect no calls to f.foo.baz
     }
   }

--- a/scalatest/src/test/scala/user/org/mockito/scalatest/IdiomaticMockitoWithExpectFixtureClassTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/scalatest/IdiomaticMockitoWithExpectFixtureClassTest.scala
@@ -1,0 +1,77 @@
+package user.org.mockito.scalatest
+
+import org.mockito.PrefixExpectations
+import org.mockito.exceptions.misusing.MissingMethodInvocationException
+import org.mockito.exceptions.verification.{ NeverWantedButInvoked, NoInteractionsWanted }
+import org.mockito.scalatest.IdiomaticMockitoBase
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{ fixture, Outcome }
+
+class IdiomaticMockitoWithExpectFixtureClassTest extends fixture.FlatSpec with IdiomaticMockitoBase with PrefixExpectations with Matchers {
+  class Foo {
+    def bar(a: String) = "bar"
+    def baz            = "baz"
+  }
+
+  class FixtureParam {
+    val foo: Foo = mock[Foo]
+  }
+
+  def withFixture(test: OneArgTest): Outcome = {
+    val theFixture = new FixtureParam
+    super.withFixture(test.toNoArgTest(theFixture))
+  }
+
+  "expect no calls TO" should "verify no calls on fixture objects methods" in { f: FixtureParam =>
+    "mocked" willBe returned by f.foo.bar("pepe")
+    "mocked" willBe returned by f.foo.baz
+
+    f.foo.bar("pepe") shouldBe "mocked"
+    f.foo.baz shouldBe "mocked"
+
+    a[NeverWantedButInvoked] should be thrownBy {
+      expect no calls to f.foo.bar(*)
+      expect no calls to f.foo.baz
+    }
+  }
+
+  "expect no calls ON" should "verify no calls on a mock inside a fixture object" in { f: FixtureParam =>
+    f.foo.bar("pepe") returns "mocked"
+
+    expect no calls on f.foo
+
+    f.foo.bar("pepe") shouldBe "mocked"
+
+    a[NoInteractionsWanted] should be thrownBy {
+      expect no calls on f.foo
+    }
+  }
+
+  it should "prevent usage of 'no calls to' when 'no calls on' is intended" in { f: FixtureParam =>
+    val exception = intercept[MissingMethodInvocationException] {
+      expect no calls to f.foo
+    }
+
+    exception.getMessage shouldBe
+    """'expect no calls to <?>' requires an argument which is 'a method call on a mock',
+        |  but [f.foo] is a mock object.
+        |
+        |The following would be correct (note the usage of 'calls to' vs 'calls on'):
+        |    expect no calls to f.foo.bar(*)
+        |    expect no calls on f.foo
+        |""".stripMargin
+  }
+
+  "expect noMore calls on" should "verify no more calls on a mock inside a fixture object" in { f: FixtureParam =>
+    f.foo.bar("pepe") returns "mocked"
+
+    f.foo.bar("pepe") shouldBe "mocked"
+
+    a[NoInteractionsWanted] should be thrownBy {
+      expect noMore calls on f.foo
+    }
+
+    expect a call to f.foo.bar(*)
+    expect noMore calls on f.foo
+  }
+}

--- a/scalatest/src/test/scala/user/org/mockito/scalatest/IdiomaticMockitoWithExpectFixtureClassTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/scalatest/IdiomaticMockitoWithExpectFixtureClassTest.scala
@@ -54,11 +54,11 @@ class IdiomaticMockitoWithExpectFixtureClassTest extends fixture.FlatSpec with I
 
     exception.getMessage shouldBe
     """'expect no calls to <?>' requires an argument which is 'a method call on a mock',
-        |  but [f.foo] is a mock object.
+        |  but looks like [f.foo] is not a method call on a mock. Is it a mock object?
         |
         |The following would be correct (note the usage of 'calls to' vs 'calls on'):
-        |    expect no calls to f.foo.bar(*)
-        |    expect no calls on f.foo
+        |    expect no calls to aMock.bar(*)
+        |    expect no calls on aMock
         |""".stripMargin
   }
 


### PR DESCRIPTION
Resolves #212 for Expect DSL