### PR TITLE
Fixes Issue #303

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,6 +751,13 @@ val failingMock: Foo = mock[Foo].returnsMT[ErrorOr, MyClass](*) returns Left(Err
 ## Mocking Scala `object`
 
 Since version 1.16.0 it is possible to mock `object` methods, given that such definitions are global, the way to mock them is sligtly different in order to ensure we restore the real implementation of the object after we are done
+
+To enable `withObjectMocked` feature, it is mandatory to create the file `src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker` containing a single line:
+ 
+```scala
+ mock-maker-inline
+```
+
 Example:
 
 ```scala

--- a/README.md
+++ b/README.md
@@ -751,6 +751,14 @@ val failingMock: Foo = mock[Foo].returnsMT[ErrorOr, MyClass](*) returns Left(Err
 ## Mocking Scala `object`
 
 Since version 1.16.0 it is possible to mock `object` methods, given that such definitions are global, the way to mock them is sligtly different in order to ensure we restore the real implementation of the object after we are done
+
+To enable `withObjectMocked` feature, it is mandatory to create the file `src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker` containing a single line:
+ 
+```scala
+ mock-maker-inline
+```
+
+
 Example:
 
 ```scala

--- a/README.md
+++ b/README.md
@@ -758,7 +758,6 @@ To enable `withObjectMocked` feature, it is mandatory to create the file `src/te
  mock-maker-inline
 ```
 
-
 Example:
 
 ```scala


### PR DESCRIPTION
This PR solves  [Issue 303](https://github.com/mockito/mockito-scala/issues/303)
To avoid 'withObjectMocked' errors it is mandatory to include MockMaker plugin. 
The documentation missed this detail.