### PR TITLE
Migrated to new Shipkit libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,12 @@ branches:
   except:
   - /^v\d/
 
-#Build and perform release (if needed)
+
 script:
-  - ./gradlew build -s && ./gradlew ciPerformRelease
+  # To validate changes, we run building and bintray upload in dry run. This happens on every build, even PRs.
+  # To publish, we perform github release and perform bintray upload (no dry run). This only for main branch builds.
+  - >
+    ./gradlew resolveVersion
+    && ./gradlew build bintrayUpload -PbintrayDryRun
+    && if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "release/1.x" ];
+      then ./gradlew bintrayUpload githubRelease; fi

--- a/build.gradle
+++ b/build.gradle
@@ -5,18 +5,25 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.shipkit:shipkit:2.0.26"
+        //Using buildscript.classpath so that we can resolve plugins from maven local, during local testing
+        classpath "org.shipkit:shipkit-auto-version:0.+"
+        classpath "org.shipkit:shipkit-changelog:0.+"
+        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.+"
     }
 }
 
-apply plugin: "org.shipkit.single-project"
+apply from: "gradle/shipkit.gradle"
+
+task resolveVersion {
+    description = "Resolves version in the 'version.properties' file for the SBT build."
+    doLast {
+        file("version.properties").text = "version=$version"
+    }
+}
 
 task build(type: Exec) {
     commandLine "./build.sh"
 }
-
-//Performing hard to reverse release operation (git push) as late as possible
-gitPush.mustRunAfter build
 
 task clean(type: Exec) {
     commandLine "./clean.sh"

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val commonSettings =
         v
       }.get)
       source.close
-      version.get
+      version.get.replace(".*", "-SNAPSHOT")
     },
     crossScalaVersions := Seq(currentScalaVersion, "2.12.12", "2.11.12"),
     scalafmtOnCompile := true,

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -1,42 +1,50 @@
-shipkit {
-    gitHub.repository = "mockito/mockito-scala"
-    gitHub.readOnlyAuthToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
-    gitHub.writeAuthToken = System.getenv("GH_WRITE_TOKEN")
+apply plugin: "org.shipkit.shipkit-auto-version"
+apply plugin: "org.shipkit.shipkit-changelog"
+apply plugin: "org.shipkit.shipkit-gh-release"
+
+tasks.named("generateChangelog") {
+    previousRevision = "v" + project.ext.'shipkit-auto-version.previous-version'
+    readOnlyToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
+    repository = "mockito/mockito-scala"
 }
 
-//all contents of this directory will be uploaded to Bintray
-ext.releaseSpec = fileTree("target/dist")
+tasks.named("githubRelease") {
+    def genTask = tasks.named("generateChangelog").get()
+    dependsOn genTask
+    repository = genTask.repository
+    changelog = genTask.outputFile
+    writeToken = System.getenv("GH_WRITE_TOKEN")
+}
 
-allprojects {
-    plugins.withId("org.shipkit.bintray") {
+apply plugin: 'com.jfrog.bintray'
 
-        //Bintray configuration is handled by JFrog Bintray Gradle Plugin
-        //For reference see the official documentation: https://github.com/bintray/gradle-bintray-plugin
-        bintray {
+//Bintray configuration is handled by JFrog Bintray Gradle Plugin
+//For reference see the official documentation: https://github.com/bintray/gradle-bintray-plugin
+bintray {
 
-            key = System.getenv("BINTRAY_API_KEY")
+    key = System.getenv("BINTRAY_API_KEY")
 
-            pkg {
-                repo = 'maven'
-                user = 'szczepiq'
-                name = 'mockito-scala'
-                userOrg = 'mockito'
-                licenses = ['MIT']
-                labels = ['mocks', 'tdd', 'unit tests']
-                publish = true //can be changed to 'false' for testing
+    pkg {
+        repo = 'maven'
+        user = 'szczepiq'
+        name = 'mockito-scala'
+        userOrg = 'mockito'
+        licenses = ['MIT']
+        labels = ['mocks', 'tdd', 'unit tests']
+        publish = true // can be changed to 'false' for testing
+        dryRun = project.hasProperty("bintrayDryRun")
 
-                filesSpec {
-                    from releaseSpec
-                    into '.'
-                }
+        filesSpec {
+            // all contents of this directory will be uploaded to Bintray
+            from fileTree("target/dist")
+            into '.'
+        }
 
-                version {
-                    mavenCentralSync {
-                        sync = true
-                        user = System.env.NEXUS_TOKEN_USER
-                        password = System.env.NEXUS_TOKEN_PWD
-                    }
-                }
+        version {
+            mavenCentralSync {
+                sync = false // TODO: true
+                user = System.env.NEXUS_TOKEN_USER
+                password = System.env.NEXUS_TOKEN_PWD
             }
         }
     }

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,3 @@
-#Version of the produced binaries. This file is intended to be checked-in.
-#It will be automatically bumped by release automation.
-version=1.16.4
-previousVersion=1.16.3
+# The version is inferred by shipkit-auto-version Gradle plugin
+# More: https://github.com/shipkit/shipkit-auto-version
+version=1.16.*


### PR DESCRIPTION
- no version bump and release notes commits
- supports concurrent merges
- no change to the contents of the published libraries

More details: https://github.com/mockito/mockito/pull/2069

Tested by running the build locally and attempting to publish to Bintray and perform GitHub release