### PR TITLE
Apply new Shipkit Auto Version plugin property

### DIFF
--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -3,7 +3,7 @@ apply plugin: "org.shipkit.shipkit-changelog"
 apply plugin: "org.shipkit.shipkit-gh-release"
 
 tasks.named("generateChangelog") {
-    previousRevision = "v" + project.ext.'shipkit-auto-version.previous-version'
+    previousRevision = project.ext.'shipkit-auto-version.previous-tag'
     readOnlyToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
     repository = "mockito/mockito-scala"
 }


### PR DESCRIPTION
Mockito Scala uses Shipkit Gradle plugins. The Shipkit Auto Version plugin exposes now new 'ext' property for getting previous revision: _project.ext.'shipkit-auto-version.previous-tag'_. This property is easier to use than earlier used _'shipkit-auto-version.previous-version'_; using it makes also code clearer. Earlier to get previous revision (e.g. for generating chengelog with Shipkit Changelog plugin) concatenation and possible conditional had to be used. Now it requires just to refer to _'shipkit-auto-version.previous-tag'_ alone.