### PR TITLE
Started using built-in token

### DIFF
--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -4,7 +4,7 @@ apply plugin: "org.shipkit.shipkit-gh-release"
 
 tasks.named("generateChangelog") {
     previousRevision = project.ext.'shipkit-auto-version.previous-tag'
-    readOnlyToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
+    readOnlyToken = System.getenv("GITHUB_TOKEN")
     repository = "mockito/mockito-scala"
 }
 
@@ -13,7 +13,7 @@ tasks.named("githubRelease") {
     dependsOn genTask
     repository = genTask.repository
     changelog = genTask.outputFile
-    writeToken = System.getenv("GH_WRITE_TOKEN")
+    writeToken = System.getenv("GITHUB_TOKEN")
 }
 
 apply plugin: 'com.jfrog.bintray'


### PR DESCRIPTION
Using the token that is "built-in" to Github Actions is cleaner. More details: https://github.com/shipkit/shipkit-changelog/issues/50

Please merge *after* the project converts to GH Actions