### PR TITLE
Continual releases to Maven Central

### DIFF
--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -43,7 +43,7 @@ bintray {
 
         version {
             mavenCentralSync {
-                sync = false //TODO: set to true
+                sync = true
                 user = System.env.NEXUS_TOKEN_USER
                 password = System.env.NEXUS_TOKEN_PWD
             }


### PR DESCRIPTION
Related to: #320

Tested by syncing manually version 1.16.11 from Bintray UI: https://repo1.maven.org/maven2/org/mockito/mockito-scala_2.12/1.16.11/