### PR TITLE
Introduce static singleton object spying with real-method-call and strict-stub default behaviour

### DIFF
--- a/common/src/main/scala/org/mockito/MockitoAPI.scala
+++ b/common/src/main/scala/org/mockito/MockitoAPI.scala
@@ -626,9 +626,8 @@ private[mockito] trait MockitoEnhancer extends MockCreator {
   /**
    * Mocks the specified object only for the context of the block
    */
-  def withObjectMocked[O <: AnyRef: ClassTag](block: => Any)(implicit defaultAnswer: DefaultAnswer, $pt: Prettifier): Unit = {
+  def withObjectMocked[O <: AnyRef: ClassTag](block: => Any)(implicit defaultAnswer: DefaultAnswer, $pt: Prettifier): Unit =
     withObject[O](_ => withSettings(defaultAnswer), block)
-  }
 
   /**
    * Spies the specified object only for the context of the block
@@ -661,8 +660,13 @@ trait LeniencySettings {
 }
 
 object LeniencySettings {
-  implicit val strictStubs: LeniencySettings = identity
-  val lenientStubs: LeniencySettings = _.lenient()
+  implicit val strictStubs: LeniencySettings = new LeniencySettings {
+    override def apply(settings: MockSettings): MockSettings = settings
+  }
+
+  val lenientStubs: LeniencySettings = new LeniencySettings {
+    override def apply(settings: MockSettings): MockSettings = settings.lenient()
+  }
 }
 
 private[mockito] trait Verifications {

--- a/common/src/main/scala/org/mockito/MockitoAPI.scala
+++ b/common/src/main/scala/org/mockito/MockitoAPI.scala
@@ -631,6 +631,10 @@ private[mockito] trait MockitoEnhancer extends MockCreator {
 
   /**
    * Spies the specified object only for the context of the block
+   *
+   * Automatically pulls in [[org.mockito.LeniencySettings#strictStubs strict stubbing]] behaviour via implicits.
+   * To override this default (strict) behaviour, bring lenient settings into implicit scope;
+   * see [[org.mockito.leniency]] for details
    */
   def withObjectSpied[O <: AnyRef: ClassTag](block: => Any)(implicit leniency: LeniencySettings, $pt: Prettifier): Unit = {
     val settings = leniency(Mockito.withSettings().defaultAnswer(CALLS_REAL_METHODS))

--- a/common/src/main/scala/org/mockito/mockito.scala
+++ b/common/src/main/scala/org/mockito/mockito.scala
@@ -613,4 +613,27 @@ package object mockito {
     new Equality[T] with Serializable {
       override def areEqual(a: T, b: Any): Boolean = Equality.default[T].areEqual(a, b)
     }
+
+  /**
+   * Implicit [[org.mockito.LeniencySettings LeniencySettings]] provided here for convenience
+   *
+   *  Neither are in implicit scope as is; pull one or the other in to activate the respective semantics, for
+   *  example:
+   *
+   *  {{{
+   *  import org.mockito.leniency.lenient
+   *
+   *  withObjectSpied[SomeObject.type] {
+   *     SomeObject.getExternalThing returns "external-thing"
+   *     SomeObject.getOtherThing returns "other-thing"
+   *     SomeObject.getExternalThing should be("external-thing")
+   *  }
+   *  }}}
+   *
+   *  Note: strict stubbing is active by default via [[org.mockito.LeniencySettings#strictStubs strictStubs]]
+   */
+  object leniency {
+    implicit val strict: LeniencySettings  = LeniencySettings.strictStubs
+    implicit val lenient: LeniencySettings = LeniencySettings.lenientStubs
+  }
 }

--- a/scalatest/src/test/scala/user/org/mockito/IdiomaticStubbingTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/IdiomaticStubbingTest.scala
@@ -3,16 +3,15 @@ package user.org.mockito
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.mockito.invocation.InvocationOnMock
-import org.mockito.{ ArgumentMatchersSugar, IdiomaticStubbing }
+import org.mockito.{ArgumentMatchersSugar, IdiomaticStubbing}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import user.org.mockito.matchers.{ ValueCaseClassInt, ValueCaseClassString, ValueClass }
-
+import user.org.mockito.matchers.{ValueCaseClassInt, ValueCaseClassString, ValueClass}
 import scala.collection.parallel.immutable
-import scala.concurrent.{ Await, Future }
+import scala.concurrent.{Await, Future}
 import scala.util.Random
 
-class IdiomaticStubbingTest extends AnyWordSpec with Matchers with ArgumentMatchersSugar with IdiomaticMockitoTestSetup with IdiomaticStubbing {
+class IdiomaticStubbingTest extends AnyWordSpec with Matchers with ArgumentMatchersSugar with IdiomaticMockitoTestSetup with IdiomaticStubbing{
 
   forAll(scenarios) { (testDouble, orgDouble, foo) =>
     testDouble should {
@@ -246,8 +245,8 @@ class IdiomaticStubbingTest extends AnyWordSpec with Matchers with ArgumentMatch
     }
   }
 
-  "doStub" should {
-    "stub a spy that would fail if the real impl is called" in {
+  "spy" should {
+    "stub a function that would fail if the real impl is called" in {
       val aSpy = spy(new Org)
 
       an[IllegalArgumentException] should be thrownBy {
@@ -264,7 +263,7 @@ class IdiomaticStubbingTest extends AnyWordSpec with Matchers with ArgumentMatch
       }
     }
 
-    "stub a spy with an answer" in {
+    "stub a function with an answer" in {
       val aSpy = spy(new Org)
 
       ((i: Int) => i * 10 + 2) willBe answered by aSpy.doSomethingWithThisInt(*)
@@ -294,6 +293,50 @@ class IdiomaticStubbingTest extends AnyWordSpec with Matchers with ArgumentMatch
 
       org.doSomethingWithThisIntAndStringAndBoolean(1, "2", v3 = true) shouldBe "not mocked"
       org.doSomethingWithThisIntAndStringAndBoolean(1, "2", v3 = false) shouldBe ""
+    }
+
+
+    "stub an object method" in {
+      FooObject.simpleMethod shouldBe "not mocked!"
+
+      withObjectSpied[FooObject.type] {
+        FooObject.simpleMethod returns "spied!"
+        FooObject.simpleMethod shouldBe "spied!"
+      }
+
+      FooObject.simpleMethod shouldBe "not mocked!"
+    }
+
+    "call real object method when not stubbed" in {
+      val now = FooObject.stateDependantMethod
+      withObjectSpied[FooObject.type] {
+        FooObject.simpleMethod returns s"spied!"
+        FooObject.simpleMethod shouldBe s"spied!"
+        FooObject.stateDependantMethod shouldBe now
+      }
+    }
+
+    "be thread safe" when {
+      "always stubbing object methods" in {
+        immutable.ParSeq.range(1, 100).foreach { i =>
+          withObjectSpied[FooObject.type] {
+            FooObject.simpleMethod returns s"spied!-$i"
+            FooObject.simpleMethod shouldBe s"spied!-$i"
+          }
+        }
+      }
+
+      "intermittently stubbing object methods" in {
+        val now = FooObject.stateDependantMethod
+        immutable.ParSeq.range(1, 100).foreach { i =>
+          if (i % 2 == 0)
+            withObjectSpied[FooObject.type] {
+              FooObject.stateDependantMethod returns i
+              FooObject.stateDependantMethod shouldBe i
+            }
+          else FooObject.stateDependantMethod shouldBe now
+        }
+      }
     }
   }
 

--- a/scalatest/src/test/scala/user/org/mockito/IdiomaticStubbingTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/IdiomaticStubbingTest.scala
@@ -3,15 +3,15 @@ package user.org.mockito
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.mockito.invocation.InvocationOnMock
-import org.mockito.{ArgumentMatchersSugar, IdiomaticStubbing}
+import org.mockito.{ ArgumentMatchersSugar, IdiomaticStubbing }
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import user.org.mockito.matchers.{ValueCaseClassInt, ValueCaseClassString, ValueClass}
+import user.org.mockito.matchers.{ ValueCaseClassInt, ValueCaseClassString, ValueClass }
 import scala.collection.parallel.immutable
-import scala.concurrent.{Await, Future}
+import scala.concurrent.{ Await, Future }
 import scala.util.Random
 
-class IdiomaticStubbingTest extends AnyWordSpec with Matchers with ArgumentMatchersSugar with IdiomaticMockitoTestSetup with IdiomaticStubbing{
+class IdiomaticStubbingTest extends AnyWordSpec with Matchers with ArgumentMatchersSugar with IdiomaticMockitoTestSetup with IdiomaticStubbing {
 
   forAll(scenarios) { (testDouble, orgDouble, foo) =>
     testDouble should {
@@ -294,7 +294,6 @@ class IdiomaticStubbingTest extends AnyWordSpec with Matchers with ArgumentMatch
       org.doSomethingWithThisIntAndStringAndBoolean(1, "2", v3 = true) shouldBe "not mocked"
       org.doSomethingWithThisIntAndStringAndBoolean(1, "2", v3 = false) shouldBe ""
     }
-
 
     "stub an object method" in {
       FooObject.simpleMethod shouldBe "not mocked!"

--- a/scalatest/src/test/scala/user/org/mockito/MockitoScalaSessionTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/MockitoScalaSessionTest.scala
@@ -362,8 +362,7 @@ class MockitoScalaSessionTest extends AnyWordSpec with IdiomaticMockito with Mat
         }
       }
 
-      println(thrown.getMessage)
-//      thrown.getMessage should startWith("Unnecessary stubbings detected")
+      thrown.getMessage should startWith("Unnecessary stubbings detected")
     }
 
     "check incorrect stubs after the expected one was called on a final class" in {
@@ -394,7 +393,7 @@ class MockitoScalaSessionTest extends AnyWordSpec with IdiomaticMockito with Mat
 
       "successfully for uncalled lenient stubs" in {
         MockitoScalaSession().run {
-          implicit val strict = LeniencySettings.lenientStubs
+          import org.mockito.leniency.lenient
 
           withObjectSpied[FooObject.type] {
             FooObject.stateDependantMethod returns 1234L
@@ -407,7 +406,7 @@ class MockitoScalaSessionTest extends AnyWordSpec with IdiomaticMockito with Mat
       "unsuccessfully for uncalled strict stubs" in {
         val thrown = the[UnnecessaryStubbingException] thrownBy {
           MockitoScalaSession().run {
-            implicit val strict = LeniencySettings.strictStubs
+            import org.mockito.leniency.strict
 
             withObjectSpied[FooObject.type] {
               FooObject.stateDependantMethod returns 1234L

--- a/scalatest/src/test/scala/user/org/mockito/MockitoScalaSessionTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/MockitoScalaSessionTest.scala
@@ -362,7 +362,8 @@ class MockitoScalaSessionTest extends AnyWordSpec with IdiomaticMockito with Mat
         }
       }
 
-      thrown.getMessage should startWith("Unnecessary stubbings detected")
+      println(thrown.getMessage)
+//      thrown.getMessage should startWith("Unnecessary stubbings detected")
     }
 
     "check incorrect stubs after the expected one was called on a final class" in {
@@ -387,6 +388,52 @@ class MockitoScalaSessionTest extends AnyWordSpec with IdiomaticMockito with Mat
       }
 
       thrown.getMessage should include("You have a NullPointerException here:")
+    }
+
+    "verify object spies" when {
+
+      "successfully for uncalled lenient stubs" in {
+        MockitoScalaSession().run {
+          implicit val strict = LeniencySettings.lenientStubs
+
+          withObjectSpied[FooObject.type] {
+            FooObject.stateDependantMethod returns 1234L
+            FooObject.simpleMethod returns s"spied!"
+            FooObject.simpleMethod shouldBe s"spied!"
+          }
+        }
+      }
+
+      "unsuccessfully for uncalled strict stubs" in {
+        val thrown = the[UnnecessaryStubbingException] thrownBy {
+          MockitoScalaSession().run {
+            implicit val strict = LeniencySettings.strictStubs
+
+            withObjectSpied[FooObject.type] {
+              FooObject.stateDependantMethod returns 1234L
+              FooObject.simpleMethod returns s"spied!"
+              FooObject.simpleMethod shouldBe s"spied!"
+            }
+          }
+        }
+
+        thrown.getMessage should include("Unnecessary stubbings detected")
+      }
+
+      "unsuccessfully by default (strict) for uncalled stubs" in {
+
+        val thrown = the[UnnecessaryStubbingException] thrownBy {
+          MockitoScalaSession().run {
+            withObjectSpied[FooObject.type] {
+              FooObject.stateDependantMethod returns 1234L
+              FooObject.simpleMethod returns s"spied!"
+              FooObject.simpleMethod shouldBe s"spied!"
+            }
+          }
+        }
+
+        thrown.getMessage should include("Unnecessary stubbings detected")
+      }
     }
   }
 }


### PR DESCRIPTION
The new `withObjectSpied[...]` works almost the same as `withObjectMocked[...]` e.g. they are both strict by default, but with the following differences:

Static singleton objects are already complete w.r.t to implementation, so the behaviour proposed here is for real methods to be called; this allows slight tweaks in its original behaviour, rather than having to reimplement in stubs.
Otherwise, `withObjectMocked[...]` can still be used.

Leniency settings are made available via an implicit parameters, with _strict_ semantics enabled by default i.e. implicitly.
I did want to spend more time looking into some leniency-related enums I saw during this work, but thought get the PR out sooner rather than later, as it currently works.
@bbonanno do you think there is some de-duplication that can be done in this area?

Finally re: the version parsing, I wanted to try these changes on some code I am working on for my client;`publishLocal` is annoying development-loop, when working across projects. I tried to use the following in my client `build.sbt`:

```sbt
lazy val scalatest = ProjectRef(file("../../OSS/mockito-scala"), "scalatest")
```

This however lead to errors locating the `version.properties` file; the changes seem to fix that. I can remove if it is considered undesirable, give also the creation of `project/Helpers.scala`