### PR TITLE
Enabled releases to Central

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,13 @@ jobs:
           java-version: 8
 
       - name: Build and publish to Bintray/MavenCentral
-        run: ./gradlew # TODO fix the release build
+        run: ./gradlew writeActualVersion
+          && export PROJECT_VERSION=`cat version.actual`
+          && ./build.sh
+          && ./gradlew publishToSonatype githubRelease # closeAndReleaseStagingRepository releaseSummary
         env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           NEXUS_TOKEN_USER: ${{secrets.NEXUS_TOKEN_USER}}
           NEXUS_TOKEN_PWD: ${{secrets.NEXUS_TOKEN_PWD}}
+          PGP_KEY: ${{secrets.PGP_KEY}}
+          PGP_PWD: ${{secrets.PGP_PWD}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         run: ./gradlew writeActualVersion
           && export PROJECT_VERSION=`cat version.actual`
           && ./build.sh
-          && ./gradlew publishToSonatype githubRelease # closeAndReleaseStagingRepository releaseSummary
+          && ./gradlew publishToSonatype githubRelease closeAndReleaseStagingRepository releaseSummary
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           NEXUS_TOKEN_USER: ${{secrets.NEXUS_TOKEN_USER}}

--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,12 @@ nexusPublishing {
     }
 }
 
+task writeActualVersion {
+    doLast {
+        file("version.actual") << "$version"
+    }
+}
+
 def isSnapshot = version.endsWith("-SNAPSHOT")
 
 if (isSnapshot) {
@@ -99,8 +105,17 @@ if (isSnapshot) {
     }
 }
 
-task writeActualVersion {
+tasks.register("releaseSummary") {
     doLast {
-        file("version.actual") << "$version"
+        if (isSnapshot) {
+            println "RELEASE SUMMARY\n" +
+                    "  SNAPSHOTS released to: https://s01.oss.sonatype.org/content/repositories/snapshots/org/mockito/kotlin/mockito-kotlin\n" +
+                    "  Release to Maven Central: SKIPPED FOR SNAPSHOTS\n" +
+                    "  Github releases: SKIPPED FOR SNAPSHOTS"
+        } else {
+            println "RELEASE SUMMARY\n" +
+                    "  Release to Maven Central (available after delay): https://repo1.maven.org/maven2/org/mockito/kotlin/mockito-kotlin/\n" +
+                    "  Github releases: https://github.com/mockito/mockito-kotlin/releases"
+        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,18 +8,99 @@ buildscript {
         //Using buildscript.classpath so that we can resolve plugins from maven local, during local testing
         classpath "org.shipkit:shipkit-auto-version:1.+"
         classpath "org.shipkit:shipkit-changelog:1.+"
-        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.+"
+        classpath "io.github.gradle-nexus:publish-plugin:1.1.0"
     }
 }
 
+group = 'org.mockito'
+
 apply from: "gradle/shipkit.gradle"
 
-task build(type: Exec) {
-    commandLine "./build.sh"
-    environment "PROJECT_VERSION", version
+apply plugin: "maven-publish"
+
+def pubNames = []
+publishing {
+publications {
+    int i = 1
+    [
+            "mockito-scala_2.11", "mockito-scala_2.12", "mockito-scala_2.13",
+            "mockito-scala-cats_2.11", "mockito-scala-cats_2.12", "mockito-scala-cats_2.13",
+            "mockito-scala-scalatest_2.11", "mockito-scala-scalatest_2.12", "mockito-scala-scalatest_2.13",
+            "mockito-scala-scalaz_2.11", "mockito-scala-scalaz_2.12", "mockito-scala-scalaz_2.13",
+            "mockito-scala-specs2_2.11", "mockito-scala-specs2_2.12", "mockito-scala-specs2_2.13",
+    ].each {pub ->
+        String pubName = "publication${i++}"
+        pubNames << pubName
+        "$pubName"(MavenPublication) {
+            groupId = 'org.mockito'
+            artifactId = pub
+
+            def jarFile = file("target/dist/org/mockito/${pub}/${version}/${pub}-${version}.jar")
+            artifact jarFile
+
+            def srcFile = file("target/dist/org/mockito/${pub}/${version}/${pub}-${version}-sources.jar")
+            artifact source: srcFile, classifier: "sources"
+
+            def jFile = file("target/dist/org/mockito/${pub}/${version}/${pub}-${version}-javadoc.jar")
+            artifact source: jFile, classifier: "javadoc"
+
+            pom {
+                withXml {
+                    def xml = asString()
+                    xml.setLength(0)
+                    def pomFile = file("target/dist/org/mockito/${pub}/${version}/${pub}-${version}.pom")
+                    assert pomFile.file
+                    xml.append(pomFile.text)
+                }
+            }
+        }
+    }
+}
 }
 
-task clean(type: Exec) {
-    commandLine "./clean.sh"
-    environment "PROJECT_VERSION", version
+apply plugin: 'signing' //https://docs.gradle.org/current/userguide/signing_plugin.html
+signing {
+    if (System.getenv("PGP_KEY")) {
+        useInMemoryPgpKeys(System.getenv("PGP_KEY"), System.getenv("PGP_PWD"))
+        pubNames.each {
+            sign publishing.publications."$it"
+        }
+    }
+}
+
+apply plugin: "io.github.gradle-nexus.publish-plugin"
+
+nexusPublishing {
+    repositories {
+        if (System.getenv("NEXUS_TOKEN_PWD")) {
+            sonatype {
+                // Publishing to: https://s01.oss.sonatype.org (faster instance)
+                nexusUrl = uri("https://s01.oss.sonatype.org/service/local/")
+                snapshotRepositoryUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+
+                username = System.getenv("NEXUS_TOKEN_USER")
+                password = System.getenv("NEXUS_TOKEN_PWD")
+            }
+        }
+    }
+}
+
+def isSnapshot = version.endsWith("-SNAPSHOT")
+
+if (isSnapshot) {
+    println "Building a -SNAPSHOT version (Github release and Maven Central tasks are skipped)"
+    tasks.named("githubRelease") {
+        //snapshot versions do not produce changelog / Github releases
+        enabled = false
+    }
+    tasks.named("closeAndReleaseStagingRepository") {
+        //snapshot binaries are available in Sonatype without the need to close the staging repo
+        enabled = false
+    }
+}
+
+task writeActualVersion {
+    doLast {
+        file("version.actual") << "$version"
+    }
 }

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -16,37 +16,3 @@ tasks.named("githubRelease") {
     githubToken = System.getenv("GITHUB_TOKEN")
     newTagRevision = System.getenv("GITHUB_SHA")
 }
-
-apply plugin: 'com.jfrog.bintray'
-
-//Bintray configuration is handled by JFrog Bintray Gradle Plugin
-//For reference see the official documentation: https://github.com/bintray/gradle-bintray-plugin
-bintray {
-
-    key = System.getenv("BINTRAY_API_KEY")
-
-    pkg {
-        repo = 'maven'
-        user = 'szczepiq'
-        name = 'mockito-scala'
-        userOrg = 'mockito'
-        licenses = ['MIT']
-        labels = ['mocks', 'tdd', 'unit tests']
-        publish = true // can be changed to 'false' for testing
-        dryRun = project.hasProperty("bintrayDryRun")
-
-        filesSpec {
-            // all contents of this directory will be uploaded to Bintray
-            from fileTree("target/dist")
-            into '.'
-        }
-
-        version {
-            mavenCentralSync {
-                //sync = true // enable after #351 is fixed. In the meantime, we will publish to Maven Central from Bintray UI
-                user = System.env.NEXUS_TOKEN_USER
-                password = System.env.NEXUS_TOKEN_PWD
-            }
-        }
-    }
-}


### PR DESCRIPTION
Needed for: #394

Got rid of Bintray because it's no longer maintained.