### PR TITLE
Correct release summary in 'build.gradle'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,13 +109,13 @@ tasks.register("releaseSummary") {
     doLast {
         if (isSnapshot) {
             println "RELEASE SUMMARY\n" +
-                    "  SNAPSHOTS released to: https://s01.oss.sonatype.org/content/repositories/snapshots/org/mockito/kotlin/mockito-kotlin\n" +
+                    "  SNAPSHOTS released to: https://s01.oss.sonatype.org/content/repositories/snapshots/org/mockito/\n" +
                     "  Release to Maven Central: SKIPPED FOR SNAPSHOTS\n" +
                     "  Github releases: SKIPPED FOR SNAPSHOTS"
         } else {
             println "RELEASE SUMMARY\n" +
-                    "  Release to Maven Central (available after delay): https://repo1.maven.org/maven2/org/mockito/kotlin/mockito-kotlin/\n" +
-                    "  Github releases: https://github.com/mockito/mockito-kotlin/releases"
+                    "  Release to Maven Central (available after delay): https://repo1.maven.org/maven2/org/mockito/\n" +
+                    "  Github releases: https://github.com/mockito/mockito-scala/releases"
         }
     }
 }


### PR DESCRIPTION
The release summary in 'build.gradle' contains links to Mockito Kotlin repos. I think these links should be replaced with the correct ones.