### PR TITLE
Reset mocks regardless if test fails or succeeds

### DIFF
--- a/scalatest/src/main/scala/org/mockito/scalatest/ResetMocksAfterEachAsyncTest.scala
+++ b/scalatest/src/main/scala/org/mockito/scalatest/ResetMocksAfterEachAsyncTest.scala
@@ -11,6 +11,6 @@ import org.scalatest.{ AsyncTestSuite, FutureOutcome }
 trait ResetMocksAfterEachAsyncTest extends AsyncTestSuite with ResetMocksAfterEachTestBase {
 
   override def withFixture(test: NoArgAsyncTest): FutureOutcome =
-    super.withFixture(test).onSucceededThen(resetAll())
+    super.withFixture(test).onCompletedThen(_ => resetAll())
 
 }


### PR DESCRIPTION
Ignore the outcome, but reset the mocks regardless if the test failed or
suceeeded. If not, tests run after a failed test may not start with a
clean state, leading to confusing errors when stubbing.