### PR TITLE
Update mockito-core version to latest 3.x

### DIFF
--- a/.bsp/sbt.json
+++ b/.bsp/sbt.json
@@ -1,1 +1,0 @@
-{"name":"sbt","version":"1.4.9","bspVersion":"2.0.0-M5","languages":["scala"],"argv":["/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home/bin/java","-Xms100m","-Xmx100m","-classpath","/usr/local/Cellar/sbt/1.4.7/libexec/bin/sbt-launch.jar","xsbt.boot.Boot","-bsp"]}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.bsp/
 .idea/
 target/
 dist/

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   val scalatestVersion = "3.2.10"
 
   val commonLibraries = Seq(
-    "org.mockito"   % "mockito-core"      % "3.6.0",
+    "org.mockito"   % "mockito-core"      % "3.12.4",
     "org.scalactic" %% "scalactic"        % scalatestVersion,
     "ru.vyarus"     % "generics-resolver" % "3.0.3"
   )


### PR DESCRIPTION
Mockito `3.6.0` fails with Java 17. Updating to latest 3.6.x also does not solve the problem, but latest 3.x fixes it.
Also passes all test cases and successfully creates artifact by `./build.sh`