### PR TITLE
Update Scala versions to 2.13.13 and 2.12.19

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import scala.io.Source
 import scala.language.postfixOps
 import sbt.io.Using
 
-val currentScalaVersion = "2.13.8"
+val currentScalaVersion = "2.13.13"
 
 inThisBuild(
   Seq(
@@ -26,7 +26,7 @@ lazy val commonSettings =
   Seq(
     organization := "org.mockito",
     // Load version from the file so that Gradle/Shipkit and SBT use the same version
-    crossScalaVersions := Seq(currentScalaVersion, "2.12.18", "2.11.12"),
+    crossScalaVersions := Seq(currentScalaVersion, "2.12.19", "2.11.12"),
     scalafmtOnCompile  := true,
     scalacOptions ++= Seq(
       "-unchecked",

--- a/specs2/src/test/scala/org/mockito/specs2/MockitoScalaNewSyntaxSpec.scala
+++ b/specs2/src/test/scala/org/mockito/specs2/MockitoScalaNewSyntaxSpec.scala
@@ -2,9 +2,9 @@ package org.mockito.specs2
 
 import java.io.{ File, FileOutputStream, ObjectOutputStream }
 import java.util
-
 import org.hamcrest.core.IsNull
 import org.mockito.IdiomaticMockitoBase.Times
+import org.mockito.VerifyOrder
 import org.mockito.captor.ArgCaptor
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.DefaultAnswer
@@ -661,7 +661,7 @@ The Mockito trait is reusable in other contexts
       "ex1" in new org.specs2.specification.Scope {
         val (list1, list2) = (mock[java.util.List[String]], mock[java.util.List[String]])
         list1.add("two"); list2.add("one")
-        implicit val order = inOrder(list1, list2)
+        implicit val order: VerifyOrder = inOrder(list1, list2)
         list2.add("two").was(called) andThen list1.add("one").was(called)
       }
     }

--- a/specs2/src/test/scala/org/mockito/specs2/MockitoScalaSpec.scala
+++ b/specs2/src/test/scala/org/mockito/specs2/MockitoScalaSpec.scala
@@ -2,8 +2,8 @@ package org.mockito.specs2
 
 import java.io.{ File, FileOutputStream, ObjectOutputStream }
 import java.util
-
 import org.hamcrest.core.IsNull
+import org.mockito.VerifyOrder
 import org.mockito.captor.ArgCaptor
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.DefaultAnswer
@@ -660,7 +660,7 @@ The Mockito trait is reusable in other contexts
       "ex1" in new org.specs2.specification.Scope {
         val (list1, list2) = (mock[java.util.List[String]], mock[java.util.List[String]])
         list1.add("two"); list2.add("one")
-        implicit val order = inOrder(list1, list2)
+        implicit val order: VerifyOrder = inOrder(list1, list2)
         there was one(list2).add("two") andThen one(list1).add("one")
       }
     }


### PR DESCRIPTION
Update as suggested [here](https://github.com/mockito/mockito-scala/issues/515#issuecomment-1826813404).

The missing type annotation [produces a warning](https://github.com/scala/scala/pull/10083) as of Scala 2.13.11.
