### PR TITLE
Create releases on tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ name: CI
 on:
   push:
     branches: ['release/2.x']
-    tags-ignore: [v*] # release tags are automatically generated after a successful CI build, no need to run CI against them
+    tags: [v*]
   pull_request:
     branches: ['**']
 
@@ -34,14 +34,13 @@ jobs:
 
       - name: 1. Check out code
         uses: actions/checkout@v2 # https://github.com/actions/checkout
-        with:
-          fetch-depth: '0' # https://github.com/shipkit/shipkit-changelog#fetch-depth-on-ci
 
       - name: 2. Set up Java ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
+          cache: 'gradle'
 
       - name: 3. Build on Java ${{ matrix.java }}
         run: ./build.sh
@@ -57,11 +56,13 @@ jobs:
   # Release job, only for pushes to the main development branch
   #
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: [build] # build job must pass before we can release
 
     if: github.event_name == 'push'
-      && github.ref == 'refs/heads/release/2.x'
+      && (github.ref == 'refs/heads/release/2.x' || startsWith(github.ref, 'refs/tags/v'))
       && github.repository == 'mockito/mockito-scala'
       && !contains(toJSON(github.event.commits.*.message), '[skip release]')
 
@@ -77,11 +78,10 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 17
+          cache: 'gradle'
 
       - name: Build and publish to Bintray/MavenCentral
-        run: ./gradlew writeActualVersion
-          && export PROJECT_VERSION=`cat version.actual`
-          && ./build.sh
+        run: ./build.sh
           && ./gradlew publishToSonatype githubRelease closeAndReleaseStagingRepository releaseSummary
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
   pull_request:
     branches: ['**']
 
+permissions:
+  contents: read
+
 jobs:
 
   #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
-          cache: 'gradle'
 
       - name: 3. Build on Java ${{ matrix.java }}
         run: ./build.sh
@@ -81,7 +80,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 17
-          cache: 'gradle'
 
       - name: Build and publish to Bintray/MavenCentral
         run: ./build.sh

--- a/build.gradle
+++ b/build.gradle
@@ -85,12 +85,6 @@ nexusPublishing {
     }
 }
 
-task writeActualVersion {
-    doLast {
-        file("version.actual") << "$version"
-    }
-}
-
 def isSnapshot = version.endsWith("-SNAPSHOT")
 
 if (isSnapshot) {

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ val currentScalaVersion = "2.13.16"
 inThisBuild(
   Seq(
     scalaVersion := currentScalaVersion,
+  )
 )
 
 lazy val commonSettings =

--- a/build.sbt
+++ b/build.sbt
@@ -7,19 +7,6 @@ val currentScalaVersion = "2.13.16"
 inThisBuild(
   Seq(
     scalaVersion := currentScalaVersion,
-    // Load version from the file so that Gradle/Shipkit and SBT use the same version
-    version := sys.env
-      .get("PROJECT_VERSION")
-      .filter(_.trim.nonEmpty)
-      .orElse {
-        lazy val VersionRE = """^version=(.+)$""".r
-        Using.file(Source.fromFile)(baseDirectory.value / "version.properties") {
-          _.getLines.collectFirst { case VersionRE(v) => v }
-        }
-      }
-      .map(_.replace(".*", "-SNAPSHOT"))
-      .get
-  )
 )
 
 lazy val commonSettings =

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,0 @@
-# The version is inferred by shipkit-auto-version Gradle plugin
-# More: https://github.com/shipkit/shipkit-auto-version
-version=2.0.*


### PR DESCRIPTION
Instead of releasing on every commit (in case of Dependabot, every dependency
update is a new commit), we now use GitHub tags instead. This is similar to
mockito-core, which also uses tags to determine when to release.