### PR TITLE
Decrease usage of deprecated elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ The library has independent developers, release cycle and versioning from core m
 If you're in Scala 2.12 you'll probably want to add the compiler flag `-Ypartial-unification`, if you don't you risk some compile errors when trying to stub complex types using the idiomatic syntax
 
 ## Notes for 2.0.0
-We dropped support for Scala 2.11 and Java 8, as Mockito 5 dropped support for Java 8.
+We dropped support for Scala 2.11 and Java 8, as Mockito 5 dropped support for Java 8. 
+Java 11 is now the minimum supported version.
 
 ## Notes for 1.13.6
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,4 @@
-import scala.io.Source
 import scala.language.postfixOps
-import sbt.io.Using
 
 val currentScalaVersion = "2.13.16"
 
@@ -21,7 +19,7 @@ lazy val commonSettings =
     scalacOptions ++= Seq(
       "-unchecked",
       "-feature",
-      "-deprecation:false",
+      "-deprecation",
       "-encoding",
       "UTF-8",
       "-Xfatal-warnings",
@@ -48,7 +46,8 @@ lazy val commonSettings =
         case _ =>
           Seq("org.scala-lang.modules" %% "scala-parallel-collections" % "1.2.0")
       }
-    }
+    },
+    libraryDependencies += "org.scala-lang.modules" %% "scala-collection-compat" % "2.13.0"
   )
 
 lazy val publishSettings = Seq(
@@ -154,8 +153,6 @@ lazy val core = (project in file("core"))
     name := "mockito-scala",
     libraryDependencies ++= Dependencies.commonLibraries,
     libraryDependencies ++= Dependencies.scalaReflection.value,
-    // TODO remove when we remove the deprecated classes in org.mockito.integrations.Dependencies.scalatest
-    libraryDependencies += Dependencies.scalatest % "provided",
     // include the macro classes and resources in the main jar
     Compile / packageBin / mappings ++= (macroSub / Compile / packageBin / mappings).value,
     // include the macro sources in the main source jar

--- a/cats/src/test/scala/org/mockito/cats/DoSomethingCatsTest.scala
+++ b/cats/src/test/scala/org/mockito/cats/DoSomethingCatsTest.scala
@@ -50,7 +50,7 @@ class DoSomethingCatsTest
       ValueClass("mocked!") willBe returnedFG by aMock.returnsFutureEither("hello")
       Error("boom") willBe raisedG by aMock.returnsFutureEither("bye")
 
-      whenReady(aMock.returnsFutureEither("hello"))(_.right.value shouldBe ValueClass("mocked!"))
+      whenReady(aMock.returnsFutureEither("hello"))(_.value shouldBe ValueClass("mocked!"))
       whenReady(aMock.returnsFutureEither("bye"))(_.left.value shouldBe Error("boom"))
     }
 
@@ -68,7 +68,7 @@ class DoSomethingCatsTest
       ValueClass("mocked!") willBe returnedF by aMock.returnsMT[ErrorOr, ValueClass](ValueClass("hi"))
       Error("error") willBe raised by aMock.returnsMT[ErrorOr, ValueClass](ValueClass("bye"))
 
-      aMock.returnsMT[ErrorOr, ValueClass](ValueClass("hi")).right.value shouldBe ValueClass("mocked!")
+      aMock.returnsMT[ErrorOr, ValueClass](ValueClass("hi")).value shouldBe ValueClass("mocked!")
       aMock.returnsMT[ErrorOr, ValueClass](ValueClass("bye")).left.value shouldBe Error("error")
     }
 
@@ -89,7 +89,7 @@ class DoSomethingCatsTest
       ValueClass("mocked!") willBe returnedF by aMock.returnsEitherT("hello")
 
       whenReady(aMock.returnsEitherT("bye").value)(_.left.value shouldBe Error("error"))
-      whenReady(aMock.returnsEitherT("hello").value)(_.right.value shouldBe ValueClass("mocked!"))
+      whenReady(aMock.returnsEitherT("hello").value)(_.value shouldBe ValueClass("mocked!"))
     }
 
     "work with OptionT" in {
@@ -125,9 +125,9 @@ class DoSomethingCatsTest
         .returnsFutureEither("hola")
       ((i: Int, b: Boolean) => s"$i, $b") willBe answeredFG by aMock.returnsFutureOptionFrom(42, true)
 
-      whenReady(aMock.returnsFutureEither("hello"))(_.right.value shouldBe ValueClass("mocked!"))
-      whenReady(aMock.returnsFutureEither("hi"))(_.right.value shouldBe ValueClass("hi mocked!"))
-      whenReady(aMock.returnsFutureEither("hola"))(_.right.value shouldBe ValueClass("hola invocation mocked!"))
+      whenReady(aMock.returnsFutureEither("hello"))(_.value shouldBe ValueClass("mocked!"))
+      whenReady(aMock.returnsFutureEither("hi"))(_.value shouldBe ValueClass("hi mocked!"))
+      whenReady(aMock.returnsFutureEither("hola"))(_.value shouldBe ValueClass("hola invocation mocked!"))
       whenReady(aMock.returnsFutureOptionFrom(42, true))(_.value shouldBe "42, true")
     }
   }

--- a/cats/src/test/scala/org/mockito/cats/IdiomaticMockitoCatsTest.scala
+++ b/cats/src/test/scala/org/mockito/cats/IdiomaticMockitoCatsTest.scala
@@ -52,7 +52,7 @@ class IdiomaticMockitoCatsTest
       aMock.returnsFutureEither("hello") returnsFG ValueClass("mocked!")
       aMock.returnsFutureEither("bye") raisesG Error("boom")
 
-      whenReady(aMock.returnsFutureEither("hello"))(_.right.value shouldBe ValueClass("mocked!"))
+      whenReady(aMock.returnsFutureEither("hello"))(_.value shouldBe ValueClass("mocked!"))
       whenReady(aMock.returnsFutureEither("bye"))(_.left.value shouldBe Error("boom"))
     }
 
@@ -76,7 +76,7 @@ class IdiomaticMockitoCatsTest
       aMock.returnsMT[ErrorOr, ValueClass](ValueClass("hi")) returnsF ValueClass("mocked!")
       aMock.returnsMT[ErrorOr, ValueClass](ValueClass("bye")) raises Error("error")
 
-      aMock.returnsMT[ErrorOr, ValueClass](ValueClass("hi")).right.value shouldBe ValueClass("mocked!")
+      aMock.returnsMT[ErrorOr, ValueClass](ValueClass("hi")).value shouldBe ValueClass("mocked!")
       aMock.returnsMT[ErrorOr, ValueClass](ValueClass("bye")).left.value shouldBe Error("error")
     }
 
@@ -125,7 +125,7 @@ class IdiomaticMockitoCatsTest
       aMock.returnsEitherT("hello") returnsF ValueClass("mocked!")
 
       whenReady(aMock.returnsEitherT("bye").value)(_.left.value shouldBe Error("error"))
-      whenReady(aMock.returnsEitherT("hello").value)(_.right.value shouldBe ValueClass("mocked!"))
+      whenReady(aMock.returnsEitherT("hello").value)(_.value shouldBe ValueClass("mocked!"))
     }
 
     "work with OptionT" in {
@@ -160,9 +160,9 @@ class IdiomaticMockitoCatsTest
       aMock.returnsFutureEither("hola") answersFG ((i: InvocationOnMock) => ValueClass(i.arg[String](0) + " invocation mocked!"))
       aMock.returnsFutureOptionFrom(42, true) answersFG ((i: Int, b: Boolean) => s"$i, $b")
 
-      whenReady(aMock.returnsFutureEither("hello"))(_.right.value shouldBe ValueClass("mocked!"))
-      whenReady(aMock.returnsFutureEither("hi"))(_.right.value shouldBe ValueClass("hi mocked!"))
-      whenReady(aMock.returnsFutureEither("hola"))(_.right.value shouldBe ValueClass("hola invocation mocked!"))
+      whenReady(aMock.returnsFutureEither("hello"))(_.value shouldBe ValueClass("mocked!"))
+      whenReady(aMock.returnsFutureEither("hi"))(_.value shouldBe ValueClass("hi mocked!"))
+      whenReady(aMock.returnsFutureEither("hola"))(_.value shouldBe ValueClass("hola invocation mocked!"))
       whenReady(aMock.returnsFutureOptionFrom(42, true))(_.value shouldBe "42, true")
     }
   }

--- a/cats/src/test/scala/org/mockito/cats/MockitoCatsTest.scala
+++ b/cats/src/test/scala/org/mockito/cats/MockitoCatsTest.scala
@@ -45,7 +45,7 @@ class MockitoCatsTest extends AnyWordSpec with Matchers with MockitoSugar with A
       whenFG(aMock.returnsFutureEither("hello")) thenReturn ValueClass("mocked!")
       whenFG(aMock.returnsFutureEither("bye")) thenFailWith Error("boom")
 
-      whenReady(aMock.returnsFutureEither("hello"))(_.right.value shouldBe ValueClass("mocked!"))
+      whenReady(aMock.returnsFutureEither("hello"))(_.value shouldBe ValueClass("mocked!"))
       whenReady(aMock.returnsFutureEither("bye"))(_.left.value shouldBe Error("boom"))
     }
 
@@ -69,7 +69,7 @@ class MockitoCatsTest extends AnyWordSpec with Matchers with MockitoSugar with A
       whenF(aMock.returnsMT[ErrorOr, ValueClass](ValueClass("hi"))) thenReturn ValueClass("mocked!")
       whenF(aMock.returnsMT[ErrorOr, ValueClass](ValueClass("bye"))) thenFailWith Error("error")
 
-      aMock.returnsMT[ErrorOr, ValueClass](ValueClass("hi")).right.value shouldBe ValueClass("mocked!")
+      aMock.returnsMT[ErrorOr, ValueClass](ValueClass("hi")).value shouldBe ValueClass("mocked!")
       aMock.returnsMT[ErrorOr, ValueClass](ValueClass("bye")).left.value shouldBe Error("error")
     }
 
@@ -103,7 +103,7 @@ class MockitoCatsTest extends AnyWordSpec with Matchers with MockitoSugar with A
       whenF(aMock.returnsEitherT("hello")) thenReturn ValueClass("mocked!")
 
       whenReady(aMock.returnsEitherT("bye").value)(_.left.value shouldBe Error("error"))
-      whenReady(aMock.returnsEitherT("hello").value)(_.right.value shouldBe ValueClass("mocked!"))
+      whenReady(aMock.returnsEitherT("hello").value)(_.value shouldBe ValueClass("mocked!"))
     }
 
     "work with OptionT" in {
@@ -138,9 +138,9 @@ class MockitoCatsTest extends AnyWordSpec with Matchers with MockitoSugar with A
       whenFG(aMock.returnsFutureEither("hola")) thenAnswer ((i: InvocationOnMock) => ValueClass(i.arg[String](0) + " invocation mocked!"))
       whenFG(aMock.returnsFutureOptionFrom(42, true)) thenAnswer ((i: Int, b: Boolean) => s"$i, $b")
 
-      whenReady(aMock.returnsFutureEither("hello"))(_.right.value shouldBe ValueClass("mocked!"))
-      whenReady(aMock.returnsFutureEither("hi"))(_.right.value shouldBe ValueClass("hi mocked!"))
-      whenReady(aMock.returnsFutureEither("hola"))(_.right.value shouldBe ValueClass("hola invocation mocked!"))
+      whenReady(aMock.returnsFutureEither("hello"))(_.value shouldBe ValueClass("mocked!"))
+      whenReady(aMock.returnsFutureEither("hi"))(_.value shouldBe ValueClass("hi mocked!"))
+      whenReady(aMock.returnsFutureEither("hola"))(_.value shouldBe ValueClass("hola invocation mocked!"))
       whenReady(aMock.returnsFutureOptionFrom(42, true))(_.value shouldBe "42, true")
     }
   }
@@ -176,7 +176,7 @@ class MockitoCatsTest extends AnyWordSpec with Matchers with MockitoSugar with A
       doReturnFG[Future, ErrorOr, ValueClass](ValueClass("mocked!")).when(aMock).returnsFutureEither("hello")
       doFailWithG[Future, ErrorOr, Error, ValueClass](Error("boom")).when(aMock).returnsFutureEither("bye")
 
-      whenReady(aMock.returnsFutureEither("hello"))(_.right.value shouldBe ValueClass("mocked!"))
+      whenReady(aMock.returnsFutureEither("hello"))(_.value shouldBe ValueClass("mocked!"))
       whenReady(aMock.returnsFutureEither("bye"))(_.left.value shouldBe Error("boom"))
     }
 
@@ -194,7 +194,7 @@ class MockitoCatsTest extends AnyWordSpec with Matchers with MockitoSugar with A
       doReturnF[ErrorOr, ValueClass](ValueClass("mocked!")).when(aMock).returnsMT(ValueClass("hi"))
       doFailWith[ErrorOr, Error, ValueClass](Error("error")).when(aMock).returnsMT(ValueClass("bye"))
 
-      aMock.returnsMT[ErrorOr, ValueClass](ValueClass("hi")).right.value shouldBe ValueClass("mocked!")
+      aMock.returnsMT[ErrorOr, ValueClass](ValueClass("hi")).value shouldBe ValueClass("mocked!")
       aMock.returnsMT[ErrorOr, ValueClass](ValueClass("bye")).left.value shouldBe Error("error")
     }
 
@@ -216,7 +216,7 @@ class MockitoCatsTest extends AnyWordSpec with Matchers with MockitoSugar with A
       doReturnF[F, ValueClass](ValueClass("mocked!")).when(aMock).returnsEitherT("hello")
 
       whenReady(aMock.returnsEitherT("bye").value)(_.left.value shouldBe Error("error"))
-      whenReady(aMock.returnsEitherT("hello").value)(_.right.value shouldBe ValueClass("mocked!"))
+      whenReady(aMock.returnsEitherT("hello").value)(_.value shouldBe ValueClass("mocked!"))
     }
 
     "work with OptionT" in {
@@ -256,9 +256,9 @@ class MockitoCatsTest extends AnyWordSpec with Matchers with MockitoSugar with A
         .returnsFutureEither("hola")
       doAnswerFG[Future, Option, Int, Boolean, String]((i: Int, b: Boolean) => s"$i, $b").when(aMock).returnsFutureOptionFrom(42, true)
 
-      whenReady(aMock.returnsFutureEither("hello"))(_.right.value shouldBe ValueClass("mocked!"))
-      whenReady(aMock.returnsFutureEither("hi"))(_.right.value shouldBe ValueClass("hi mocked!"))
-      whenReady(aMock.returnsFutureEither("hola"))(_.right.value shouldBe ValueClass("hola invocation mocked!"))
+      whenReady(aMock.returnsFutureEither("hello"))(_.value shouldBe ValueClass("mocked!"))
+      whenReady(aMock.returnsFutureEither("hi"))(_.value shouldBe ValueClass("hi mocked!"))
+      whenReady(aMock.returnsFutureEither("hola"))(_.value shouldBe ValueClass("hola invocation mocked!"))
       whenReady(aMock.returnsFutureOptionFrom(42, true))(_.value shouldBe "42, true")
     }
   }

--- a/cats/src/test/scala/org/mockito/cats/instances/ArgumentMatcherInstancesTest.scala
+++ b/cats/src/test/scala/org/mockito/cats/instances/ArgumentMatcherInstancesTest.scala
@@ -80,7 +80,7 @@ class ArgumentMatcherInstancesTest extends AnyFunSuiteLike with FunSuiteDiscipli
   test("EqTo works with cats syntax") {
     val aMock = mock[Foo]
 
-    val matcher = (EqTo("foo"), EqTo(new Integer(42))).tupled
+    val matcher = (EqTo("foo"), EqTo(Integer.valueOf(42))).tupled
     aMock.takesTuple(argThat(matcher)) returns "mocked!"
 
     aMock.takesTuple("foo", 42) shouldBe "mocked!"

--- a/common/src/main/scala/org/mockito/MockitoAPI.scala
+++ b/common/src/main/scala/org/mockito/MockitoAPI.scala
@@ -24,10 +24,12 @@ import org.mockito.internal.util.reflection.LenientCopyTool
 import org.mockito.internal.{ ValueClassExtractor, ValueClassWrapper }
 import org.mockito.invocation.{ Invocation, InvocationContainer, InvocationOnMock, MockHandler }
 import org.mockito.mock.MockCreationSettings
+import org.mockito.quality.Strictness
 import org.mockito.stubbing._
 import org.mockito.verification.{ VerificationAfterDelay, VerificationMode, VerificationWithTimeout }
 import org.scalactic.{ Equality, Prettifier }
-import scala.collection.JavaConverters._
+
+import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.WeakTypeTag
 
@@ -543,7 +545,7 @@ private[mockito] trait MockitoEnhancer extends MockCreator {
 
   def spy[T <: AnyRef: ClassTag: WeakTypeTag](realObj: T, lenient: Boolean = false)(implicit $pt: Prettifier): T = {
     def mockSettings: MockSettings = Mockito.withSettings().defaultAnswer(CALLS_REAL_METHODS).spiedInstance(realObj)
-    val settings                   = if (lenient) mockSettings.lenient() else mockSettings
+    val settings                   = if (lenient) mockSettings.strictness(Strictness.LENIENT) else mockSettings
     mock[T](settings)
   }
 
@@ -584,7 +586,7 @@ private[mockito] trait MockitoEnhancer extends MockCreator {
         ignoreDefaultArguments(m)
         Mockito.verifyNoMoreInteractions(m)
       case t: Array[AnyRef] =>
-        verifyNoMoreInteractions(t: _*)
+        verifyNoMoreInteractions(t.toIndexedSeq: _*)
       case _ =>
         throw notAMockPassedToVerifyNoMoreInteractions
     }
@@ -645,7 +647,7 @@ object LeniencySettings {
   }
 
   val lenientStubs: LeniencySettings = new LeniencySettings {
-    override def apply(settings: MockSettings): MockSettings = settings.lenient()
+    override def apply(settings: MockSettings): MockSettings = settings.strictness(Strictness.LENIENT)
   }
 }
 

--- a/common/src/main/scala/org/mockito/ReflectionUtils.scala
+++ b/common/src/main/scala/org/mockito/ReflectionUtils.scala
@@ -9,18 +9,12 @@ import ru.vyarus.java.generics.resolver.GenericsResolver
 
 import scala.reflect.ClassTag
 import scala.reflect.internal.Symbols
-import scala.util.{ Failure, Success, Try => uTry }
+import scala.util.{ Try => uTry }
 import scala.util.control.NonFatal
 
 object ReflectionUtils {
   import scala.reflect.runtime.{ universe => ru }
   import ru._
-
-  private val JavaVersion: Int =
-    System.getProperty("java.version").split("\\.") match {
-      case Array("1", v, _*) => v.toInt // Java 8 style: 1.8.x
-      case Array(v, _*)      => v.toInt // Java 9+ style: 11.x, 17.x, etc.
-    }
 
   implicit def symbolToMethodSymbol(sym: Symbol): Symbols#MethodSymbol = sym.asInstanceOf[Symbols#MethodSymbol]
 
@@ -120,39 +114,6 @@ object ReflectionUtils {
     }
 
   def setFinalStatic(field: Field, newValue: AnyRef): Unit =
-    if (JavaVersion < 17)
-      setFinalStatic17Minus(field, newValue)
-    else
-      setFinalStatic17Plus(field, newValue)
-
-  private def setFinalStatic17Minus(field: Field, newValue: AnyRef): Unit = {
-    val clazz = classOf[java.lang.Class[_]]
-    field.setAccessible(true)
-    val modifiersField: Field = uTry(clazz.getDeclaredField("modifiers")) match {
-      case Success(modifiers) => modifiers
-      case Failure(e)         =>
-        uTry {
-          val getDeclaredFields0           = clazz.getDeclaredMethod("getDeclaredFields0", classOf[Boolean])
-          val accessibleBeforeSet: Boolean = getDeclaredFields0.isAccessible
-          getDeclaredFields0.setAccessible(true)
-          val declaredFields: Array[Field] = getDeclaredFields0
-            .invoke(classOf[Field], java.lang.Boolean.FALSE)
-            .asInstanceOf[Array[Field]]
-          getDeclaredFields0.setAccessible(accessibleBeforeSet)
-          declaredFields.find("modifiers" == _.getName).get
-        } match {
-          case Success(modifiers) => modifiers
-          case Failure(ex)        =>
-            e.addSuppressed(ex)
-            throw e
-        }
-    }
-    modifiersField.setAccessible(true)
-    modifiersField.setInt(field, field.getModifiers & ~Modifier.FINAL)
-    field.set(null, newValue)
-  }
-
-  private def setFinalStatic17Plus(field: Field, newValue: AnyRef): Unit =
     try {
       // Try to get Unsafe instance (works with both sun.misc.Unsafe and jdk.internal.misc.Unsafe)
       val unsafeClass: Class[_] =
@@ -170,6 +131,9 @@ object ReflectionUtils {
       val staticFieldBaseMethod   = unsafeClass.getMethod("staticFieldBase", classOf[Field])
       val staticFieldOffsetMethod = unsafeClass.getMethod("staticFieldOffset", classOf[Field])
       val putObjectMethod         = unsafeClass.getMethod("putObject", classOf[Object], classOf[Long], classOf[Object])
+
+      // Make the field accessible
+      field.setAccessible(true)
 
       // Get base and offset for the field
       val base: Object = staticFieldBaseMethod.invoke(unsafe, field)

--- a/common/src/main/scala/org/mockito/internal/handler/ScalaMockHandler.scala
+++ b/common/src/main/scala/org/mockito/internal/handler/ScalaMockHandler.scala
@@ -3,7 +3,6 @@ package internal.handler
 
 import java.lang.reflect.Method
 import java.util.regex.Pattern
-
 import org.mockito.ReflectionUtils.methodsWithLazyOrVarArgs
 import org.mockito.internal.handler.ScalaMockHandler._
 import org.mockito.internal.invocation._
@@ -14,7 +13,9 @@ import org.mockito.mock.MockCreationSettings
 import org.scalactic.Prettifier
 import org.scalactic.TripleEquals._
 
-import scala.collection.JavaConverters._
+import scala.annotation.nowarn
+import scala.collection.compat._
+import scala.jdk.CollectionConverters._
 
 class ScalaMockHandler[T](mockSettings: MockCreationSettings[T], methodsToProcess: Seq[(Method, Set[Int])])(implicit $pt: Prettifier) extends MockHandlerImpl[T](mockSettings) {
   override def handle(invocation: Invocation): AnyRef =
@@ -22,7 +23,7 @@ class ScalaMockHandler[T](mockSettings: MockCreationSettings[T], methodsToProces
       case i: InterceptedInvocation =>
         val method     = i.getMethod
         val methodName = method.getName
-        val realMethod = i.getRealMethod
+        val realMethod = i.getRealMethod: @nowarn("cat=deprecation")
         if (realMethod.isInvokable && (methodName.contains("$default$") || ExecuteIfSpecialised(methodName)))
           i.callRealMethod()
         else {
@@ -32,7 +33,7 @@ class ScalaMockHandler[T](mockSettings: MockCreationSettings[T], methodsToProces
             else rawArguments
 
           val scalaInvocation =
-            new ScalaInvocation(i.getMockRef, i.getMockitoMethod, arguments, rawArguments, realMethod, i.getLocation, i.getSequenceNumber)
+            new ScalaInvocation(i.getMockRef, i.getMockitoMethod, arguments, rawArguments, realMethod, i.getLocation, i.getSequenceNumber): @nowarn("cat=deprecation")
           super.handle(scalaInvocation)
         }
       case other => super.handle(other)
@@ -43,7 +44,7 @@ class ScalaMockHandler[T](mockSettings: MockCreationSettings[T], methodsToProces
       .collectFirst {
         case (mtd, indices) if method === mtd =>
           val argumentMatcherStorage                     = mockingProgress().getArgumentMatcherStorage
-          val matchers                                   = argumentMatcherStorage.pullLocalizedMatchers().asScala.toIterator
+          val matchers                                   = argumentMatcherStorage.pullLocalizedMatchers().asScala.iterator
           val matchersWereUsed                           = matchers.nonEmpty
           def reportMatcher(): Unit                      = if (matchers.nonEmpty) argumentMatcherStorage.reportMatcher(matchers.next().getMatcher)
           def reportMatchers(varargs: Iterable[_]): Unit =
@@ -51,9 +52,9 @@ class ScalaMockHandler[T](mockSettings: MockCreationSettings[T], methodsToProces
               def reportAsEqTo(): Unit = varargs.map(EqTo(_)).foreach(argumentMatcherStorage.reportMatcher(_))
               val matcher              = matchers.next().getMatcher
               matcher match {
-                case EqTo(value: Array[_]) if varargs.sameElements(value) => reportAsEqTo()
-                case EqTo(value) if varargs == value                      => reportAsEqTo()
-                case other                                                =>
+                case EqTo(value: Array[_]) if varargs.iterator.sameElements(value.iterator) => reportAsEqTo()
+                case EqTo(value) if varargs == value                                        => reportAsEqTo()
+                case other                                                                  =>
                   argumentMatcherStorage.reportMatcher(other)
                   varargs.drop(1).foreach(_ => reportMatcher())
               }

--- a/common/src/main/scala/org/mockito/internal/invocation/ScalaInvocation.scala
+++ b/common/src/main/scala/org/mockito/internal/invocation/ScalaInvocation.scala
@@ -13,7 +13,7 @@ import org.mockito.invocation.{ Invocation, Location, StubInfo }
 import org.mockito.matchers.EqTo
 import org.scalactic.Prettifier
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class ScalaInvocation(
     val mockRef: MockReference[AnyRef],

--- a/common/src/main/scala/org/mockito/stubbing/ReturnsSmartNulls.scala
+++ b/common/src/main/scala/org/mockito/stubbing/ReturnsSmartNulls.scala
@@ -7,6 +7,7 @@ import org.mockito.internal.exceptions.Reporter.smartNullPointerException
 import org.mockito.internal.stubbing.defaultanswers.ReturnsMoreEmptyValues
 import org.mockito.internal.util.ObjectMethodsGuru.isToStringMethod
 import org.mockito.invocation.{ InvocationOnMock, Location }
+import org.mockito.quality.Strictness
 
 object ReturnsSmartNulls extends DefaultAnswer {
   val delegate = new ReturnsMoreEmptyValues
@@ -16,7 +17,7 @@ object ReturnsSmartNulls extends DefaultAnswer {
       val returnType = invocation.returnType
 
       if (!returnType.isPrimitive && !isFinal(returnType.getModifiers) && classOf[Object] != returnType)
-        Some(mock(returnType, withSettings.defaultAnswer(ThrowsSmartNullPointer(invocation)).lenient()))
+        Some(mock(returnType, withSettings.defaultAnswer(ThrowsSmartNullPointer(invocation)).strictness(Strictness.LENIENT)))
       else
         None
     }

--- a/core/src/main/scala/org/mockito/MockitoScalaSession.scala
+++ b/core/src/main/scala/org/mockito/MockitoScalaSession.scala
@@ -11,7 +11,7 @@ import org.mockito.session.MockitoSessionLogger
 import org.scalactic.Equality
 import org.scalactic.TripleEquals._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 
 class MockitoScalaSession(name: String, strictness: Strictness, logger: MockitoSessionLogger) {
@@ -156,7 +156,7 @@ object MockitoScalaSession {
     private val mocks = mutable.Set.empty[AnyRef]
 
     override def onMockCreated(mock: AnyRef, settings: MockCreationSettings[_]): Unit =
-      if (!settings.isLenient && (strictness !== Strictness.Lenient)) mocks += mock
+      if ((settings.getStrictness !== JavaStrictness.LENIENT) && (strictness !== Strictness.Lenient)) mocks += mock
   }
 }
 

--- a/macro/src/main/scala/org/mockito/ExpectMacro.scala
+++ b/macro/src/main/scala/org/mockito/ExpectMacro.scala
@@ -61,7 +61,7 @@ object ExpectMacro extends VerificationMacroTransformer {
         q"verification(_root_.org.mockito.MockitoSugar.verifyNoMoreInteractions($obj))"
 
       case q"$_.this.expect.noMore($_.calls.apply($_.ignoringStubs)).on($obj)" =>
-        q"verification(_root_.org.mockito.MockitoSugar.verifyNoMoreInteractions(_root_.org.mockito.MockitoSugar.ignoreStubs($obj): _*))"
+        q"verification(_root_.org.mockito.MockitoSugar.verifyNoMoreInteractions(_root_.org.mockito.MockitoSugar.ignoreStubs($obj).toIndexedSeq: _*))"
 
       case _ => throw new Exception(s"Expect-on macro: couldn't recognize invocation ${show(called)}")
     }

--- a/macro/src/main/scala/org/mockito/VerifyMacro.scala
+++ b/macro/src/main/scala/org/mockito/VerifyMacro.scala
@@ -95,7 +95,7 @@ private[mockito] trait VerificationMacroTransformer {
         case q"$_.called"                              => q"verification(_root_.org.mockito.MockitoSugar.verifyZeroInteractions($obj))"
         case q"$_.calledAgain"                         => q"verification(_root_.org.mockito.MockitoSugar.verifyNoMoreInteractions($obj))"
         case q"$_.calledAgain.apply($_.ignoringStubs)" =>
-          q"verification(_root_.org.mockito.MockitoSugar.verifyNoMoreInteractions(_root_.org.mockito.MockitoSugar.ignoreStubs($obj): _*))"
+          q"verification(_root_.org.mockito.MockitoSugar.verifyNoMoreInteractions(_root_.org.mockito.MockitoSugar.ignoreStubs($obj).toIndexedSeq: _*))"
       }
 
     called match {

--- a/macro/src/main/scala/org/mockito/captor/Captor.scala
+++ b/macro/src/main/scala/org/mockito/captor/Captor.scala
@@ -9,7 +9,7 @@ import org.mockito.{ clazz, ArgumentCaptor }
 import org.scalactic.Equality
 import org.scalactic.TripleEquals._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 import scala.reflect.macros.blackbox
 import scala.util.{ Failure, Try }
@@ -69,7 +69,7 @@ object Captor {
     val r = if (isValueClass) c.Expr[Captor[T]] {
       val param = tpe.decls
         .collectFirst {
-          case m: MethodSymbol if m.isPrimaryConstructor ⇒ m
+          case m: MethodSymbol if m.isPrimaryConstructor => m
         }
         .get
         .paramLists

--- a/scalatest/src/main/scala/org/mockito/scalatest/ResetMocksAfterEachTestBase.scala
+++ b/scalatest/src/main/scala/org/mockito/scalatest/ResetMocksAfterEachTestBase.scala
@@ -6,12 +6,12 @@ import org.mockito.stubbing.DefaultAnswer
 import org.mockito.{ MockCreator, MockSettings }
 import org.scalactic.Prettifier
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.WeakTypeTag
 
 /**
- * It automatically resets each mock after a each test is run, useful when we need to pass the mocks to some framework once at the beginning of the test suite
+ * It automatically resets each mock after each test is run, useful when we need to pass the mocks to some framework once at the beginning of the test suite
  *
  * Just mix-in after your favourite suite, i.e. {{{class MyTest extends PlaySpec with MockitoSugar with ResetMocksAfterEachTest}}}
  */

--- a/scalatest/src/test/scala/user/org/mockito/MockitoScalaSessionTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/MockitoScalaSessionTest.scala
@@ -206,7 +206,7 @@ class MockitoScalaSessionTest extends AnyWordSpec with IdiomaticMockito with Mat
 
       "don't check unexpected calls for lenient mocks" in
       MockitoScalaSession().run {
-        val aFoo = parametrisedFoo(withSettings.lenient())
+        val aFoo = parametrisedFoo(withSettings.strictness(Strictness.LENIENT))
 
         aFoo.bar("pepe") returns "mocked"
 
@@ -241,7 +241,7 @@ class MockitoScalaSessionTest extends AnyWordSpec with IdiomaticMockito with Mat
 
       "don't check unused stubs for lenient" in
       MockitoScalaSession().run {
-        val aFoo = parametrisedFoo(withSettings.lenient())
+        val aFoo = parametrisedFoo(withSettings.strictness(Strictness.LENIENT))
 
         aFoo.bar("pepe") returns "mocked"
       }

--- a/scalatest/src/test/scala/user/org/mockito/MockitoSugarTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/MockitoSugarTest.scala
@@ -234,7 +234,7 @@ class MockitoSugarTest extends AnyWordSpec with MockitoSugar with Matchers with 
 
         when(aMock.method) thenReturn Some(Right("Mocked!"))
 
-        aMock.method.value.right.value shouldBe "Mocked!"
+        aMock.method.value.value shouldBe "Mocked!"
         aMock.method2
       }
 
@@ -243,7 +243,7 @@ class MockitoSugarTest extends AnyWordSpec with MockitoSugar with Matchers with 
 
         when(aMock.method) thenReturn Some(Right("Mocked!"))
 
-        aMock.method.value.right.value shouldBe "Mocked!"
+        aMock.method.value.value shouldBe "Mocked!"
         aMock.method2
       }
 
@@ -255,7 +255,7 @@ class MockitoSugarTest extends AnyWordSpec with MockitoSugar with Matchers with 
 
         whenGetById(aMock) thenReturn Some(Right("Mocked!"))
 
-        aMock.method.value.right.value shouldBe "Mocked!"
+        aMock.method.value.value shouldBe "Mocked!"
       }
 
       "work with standard mixins" in {

--- a/scalatest/src/test/scala/user/org/mockito/PostfixVerificationsTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/PostfixVerificationsTest.scala
@@ -676,7 +676,7 @@ class PostfixVerificationsTest extends AnyWordSpec with IdiomaticMockitoTestSetu
 
       org.unit().doesNothing()
 
-      org.unit() shouldBe ()
+      org.unit() shouldBe ((): Unit)
     }
 
     "stub a real call" in {
@@ -716,7 +716,7 @@ class PostfixVerificationsTest extends AnyWordSpec with IdiomaticMockitoTestSetu
 
       aMock.varargMethod("hola", 1, 2, 3) shouldBe 42
 
-      aMock.varargMethod("hola", Array(1, 2, 3): _*) was called
+      aMock.varargMethod("hola", List(1, 2, 3): _*) was called
       aMock.varargMethod("hola", Vector(1, 2, 3): _*) was called
       aMock.varargMethod("hola", 1, 2, 3) was called
     }

--- a/scalatest/src/test/scala/user/org/mockito/PrefixExpectationsTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/PrefixExpectationsTest.scala
@@ -700,7 +700,7 @@ class PrefixExpectationsTest extends AnyWordSpec with Matchers with ArgumentMatc
 
       org.unit().doesNothing()
 
-      org.unit() shouldBe ()
+      org.unit() shouldBe ((): Unit)
     }
 
     "stub a real call" in {
@@ -742,7 +742,7 @@ class PrefixExpectationsTest extends AnyWordSpec with Matchers with ArgumentMatc
 
       aMock.varargMethod("hola", 1, 2, 3) shouldBe 42
 
-      expect a call to aMock.varargMethod("hola", Array(1, 2, 3): _*)
+      expect a call to aMock.varargMethod("hola", List(1, 2, 3): _*)
       expect a call to aMock.varargMethod("hola", Vector(1, 2, 3): _*)
       expect a call to aMock.varargMethod("hola", 1, 2, 3)
     }

--- a/scalaz/src/test/scala/org/mockito/scalaz/DoSomethingScalazTest.scala
+++ b/scalaz/src/test/scala/org/mockito/scalaz/DoSomethingScalazTest.scala
@@ -51,7 +51,7 @@ class DoSomethingScalazTest
       ValueClass("mocked!") willBe returnedFG by aMock.returnsFutureEither("hello")
       Error("boom") willBe raisedG by aMock.returnsFutureEither("bye")
 
-      whenReady(aMock.returnsFutureEither("hello"))(_.right.value shouldBe ValueClass("mocked!"))
+      whenReady(aMock.returnsFutureEither("hello"))(_.value shouldBe ValueClass("mocked!"))
       whenReady(aMock.returnsFutureEither("bye"))(_.left.value shouldBe Error("boom"))
     }
 
@@ -69,7 +69,7 @@ class DoSomethingScalazTest
       ValueClass("mocked!") willBe returnedF by aMock.returnsMT[ErrorOr, ValueClass](ValueClass("hi"))
       Error("error") willBe raised by aMock.returnsMT[ErrorOr, ValueClass](ValueClass("bye"))
 
-      aMock.returnsMT[ErrorOr, ValueClass](ValueClass("hi")).right.value shouldBe ValueClass("mocked!")
+      aMock.returnsMT[ErrorOr, ValueClass](ValueClass("hi")).value shouldBe ValueClass("mocked!")
       aMock.returnsMT[ErrorOr, ValueClass](ValueClass("bye")).left.value shouldBe Error("error")
     }
 
@@ -90,7 +90,7 @@ class DoSomethingScalazTest
       ValueClass("mocked!") willBe returnedF by aMock.returnsEitherT("hello")
 
       whenReady(aMock.returnsEitherT("bye").run)(_.toEither.left.value shouldBe Error("error"))
-      whenReady(aMock.returnsEitherT("hello").run)(_.toEither.right.value shouldBe ValueClass("mocked!"))
+      whenReady(aMock.returnsEitherT("hello").run)(_.toEither.value shouldBe ValueClass("mocked!"))
     }
 
     "work with OptionT" in {
@@ -126,9 +126,9 @@ class DoSomethingScalazTest
         .returnsFutureEither("hola")
       ((i: Int, b: Boolean) => s"$i, $b") willBe answeredFG by aMock.returnsFutureOptionFrom(42, true)
 
-      whenReady(aMock.returnsFutureEither("hello"))(_.right.value shouldBe ValueClass("mocked!"))
-      whenReady(aMock.returnsFutureEither("hi"))(_.right.value shouldBe ValueClass("hi mocked!"))
-      whenReady(aMock.returnsFutureEither("hola"))(_.right.value shouldBe ValueClass("hola invocation mocked!"))
+      whenReady(aMock.returnsFutureEither("hello"))(_.value shouldBe ValueClass("mocked!"))
+      whenReady(aMock.returnsFutureEither("hi"))(_.value shouldBe ValueClass("hi mocked!"))
+      whenReady(aMock.returnsFutureEither("hola"))(_.value shouldBe ValueClass("hola invocation mocked!"))
       whenReady(aMock.returnsFutureOptionFrom(42, true))(_.value shouldBe "42, true")
     }
   }

--- a/scalaz/src/test/scala/org/mockito/scalaz/IdiomaticMockitoScalazTest.scala
+++ b/scalaz/src/test/scala/org/mockito/scalaz/IdiomaticMockitoScalazTest.scala
@@ -52,7 +52,7 @@ class IdiomaticMockitoScalazTest
       aMock.returnsFutureEither("hello") returnsFG ValueClass("mocked!")
       aMock.returnsFutureEither("bye") raisesG Error("boom")
 
-      whenReady(aMock.returnsFutureEither("hello"))(_.right.value shouldBe ValueClass("mocked!"))
+      whenReady(aMock.returnsFutureEither("hello"))(_.value shouldBe ValueClass("mocked!"))
       whenReady(aMock.returnsFutureEither("bye"))(_.left.value shouldBe Error("boom"))
     }
 
@@ -76,7 +76,7 @@ class IdiomaticMockitoScalazTest
       aMock.returnsMT[ErrorOr, ValueClass](ValueClass("hi")) returnsF ValueClass("mocked!")
       aMock.returnsMT[ErrorOr, ValueClass](ValueClass("bye")) raises Error("error")
 
-      aMock.returnsMT[ErrorOr, ValueClass](ValueClass("hi")).right.value shouldBe ValueClass("mocked!")
+      aMock.returnsMT[ErrorOr, ValueClass](ValueClass("hi")).value shouldBe ValueClass("mocked!")
       aMock.returnsMT[ErrorOr, ValueClass](ValueClass("bye")).left.value shouldBe Error("error")
     }
 
@@ -127,7 +127,7 @@ class IdiomaticMockitoScalazTest
       aMock.returnsEitherT("hello") returnsF ValueClass("mocked!")
 
       whenReady(aMock.returnsEitherT("bye").run)(_.toEither.left.value shouldBe Error("error"))
-      whenReady(aMock.returnsEitherT("hello").run)(_.toEither.right.value shouldBe ValueClass("mocked!"))
+      whenReady(aMock.returnsEitherT("hello").run)(_.toEither.value shouldBe ValueClass("mocked!"))
     }
 
     "work with OptionT" in {
@@ -162,9 +162,9 @@ class IdiomaticMockitoScalazTest
       aMock.returnsFutureEither("hola") answersFG ((i: InvocationOnMock) => ValueClass(i.arg[String](0) + " invocation mocked!"))
       aMock.returnsFutureOptionFrom(42, true) answersFG ((i: Int, b: Boolean) => s"$i, $b")
 
-      whenReady(aMock.returnsFutureEither("hello"))(_.right.value shouldBe ValueClass("mocked!"))
-      whenReady(aMock.returnsFutureEither("hi"))(_.right.value shouldBe ValueClass("hi mocked!"))
-      whenReady(aMock.returnsFutureEither("hola"))(_.right.value shouldBe ValueClass("hola invocation mocked!"))
+      whenReady(aMock.returnsFutureEither("hello"))(_.value shouldBe ValueClass("mocked!"))
+      whenReady(aMock.returnsFutureEither("hi"))(_.value shouldBe ValueClass("hi mocked!"))
+      whenReady(aMock.returnsFutureEither("hola"))(_.value shouldBe ValueClass("hola invocation mocked!"))
       whenReady(aMock.returnsFutureOptionFrom(42, true))(_.value shouldBe "42, true")
     }
   }

--- a/scalaz/src/test/scala/org/mockito/scalaz/MockitoScalazTest.scala
+++ b/scalaz/src/test/scala/org/mockito/scalaz/MockitoScalazTest.scala
@@ -44,7 +44,7 @@ class MockitoScalazTest extends AnyWordSpec with Matchers with MockitoSugar with
       whenFG(aMock.returnsFutureEither("hello")) thenReturn ValueClass("mocked!")
       whenFG(aMock.returnsFutureEither("bye")) thenFailWith Error("boom")
 
-      whenReady(aMock.returnsFutureEither("hello"))(_.right.value shouldBe ValueClass("mocked!"))
+      whenReady(aMock.returnsFutureEither("hello"))(_.value shouldBe ValueClass("mocked!"))
       whenReady(aMock.returnsFutureEither("bye"))(_.left.value shouldBe Error("boom"))
     }
 
@@ -68,7 +68,7 @@ class MockitoScalazTest extends AnyWordSpec with Matchers with MockitoSugar with
       whenF(aMock.returnsMT[ErrorOr, ValueClass](ValueClass("hi"))) thenReturn ValueClass("mocked!")
       whenF(aMock.returnsMT[ErrorOr, ValueClass](ValueClass("bye"))) thenFailWith Error("error")
 
-      aMock.returnsMT[ErrorOr, ValueClass](ValueClass("hi")).right.value shouldBe ValueClass("mocked!")
+      aMock.returnsMT[ErrorOr, ValueClass](ValueClass("hi")).value shouldBe ValueClass("mocked!")
       aMock.returnsMT[ErrorOr, ValueClass](ValueClass("bye")).left.value shouldBe Error("error")
     }
 
@@ -104,7 +104,7 @@ class MockitoScalazTest extends AnyWordSpec with Matchers with MockitoSugar with
       whenF(aMock.returnsEitherT("hello")) thenReturn ValueClass("mocked!")
 
       whenReady(aMock.returnsEitherT("bye").run)(_.toEither.left.value shouldBe Error("error"))
-      whenReady(aMock.returnsEitherT("hello").run)(_.toEither.right.value shouldBe ValueClass("mocked!"))
+      whenReady(aMock.returnsEitherT("hello").run)(_.toEither.value shouldBe ValueClass("mocked!"))
     }
 
     "work with OptionT" in {
@@ -139,9 +139,9 @@ class MockitoScalazTest extends AnyWordSpec with Matchers with MockitoSugar with
       whenFG(aMock.returnsFutureEither("hola")) thenAnswer ((i: InvocationOnMock) => ValueClass(i.arg[String](0) + " invocation mocked!"))
       whenFG(aMock.returnsFutureOptionFrom(42, true)) thenAnswer ((i: Int, b: Boolean) => s"$i, $b")
 
-      whenReady(aMock.returnsFutureEither("hello"))(_.right.value shouldBe ValueClass("mocked!"))
-      whenReady(aMock.returnsFutureEither("hi"))(_.right.value shouldBe ValueClass("hi mocked!"))
-      whenReady(aMock.returnsFutureEither("hola"))(_.right.value shouldBe ValueClass("hola invocation mocked!"))
+      whenReady(aMock.returnsFutureEither("hello"))(_.value shouldBe ValueClass("mocked!"))
+      whenReady(aMock.returnsFutureEither("hi"))(_.value shouldBe ValueClass("hi mocked!"))
+      whenReady(aMock.returnsFutureEither("hola"))(_.value shouldBe ValueClass("hola invocation mocked!"))
       whenReady(aMock.returnsFutureOptionFrom(42, true))(_.value shouldBe "42, true")
     }
   }
@@ -177,7 +177,7 @@ class MockitoScalazTest extends AnyWordSpec with Matchers with MockitoSugar with
       doReturnFG[Future, ErrorOr, ValueClass](ValueClass("mocked!")).when(aMock).returnsFutureEither("hello")
       doFailWithG[Future, ErrorOr, Error, ValueClass](Error("boom")).when(aMock).returnsFutureEither("bye")
 
-      whenReady(aMock.returnsFutureEither("hello"))(_.right.value shouldBe ValueClass("mocked!"))
+      whenReady(aMock.returnsFutureEither("hello"))(_.value shouldBe ValueClass("mocked!"))
       whenReady(aMock.returnsFutureEither("bye"))(_.left.value shouldBe Error("boom"))
     }
 
@@ -195,7 +195,7 @@ class MockitoScalazTest extends AnyWordSpec with Matchers with MockitoSugar with
       doReturnF[ErrorOr, ValueClass](ValueClass("mocked!")).when(aMock).returnsMT(ValueClass("hi"))
       doFailWith[ErrorOr, Error, ValueClass](Error("error")).when(aMock).returnsMT(ValueClass("bye"))
 
-      aMock.returnsMT[ErrorOr, ValueClass](ValueClass("hi")).right.value shouldBe ValueClass("mocked!")
+      aMock.returnsMT[ErrorOr, ValueClass](ValueClass("hi")).value shouldBe ValueClass("mocked!")
       aMock.returnsMT[ErrorOr, ValueClass](ValueClass("bye")).left.value shouldBe Error("error")
     }
 
@@ -217,7 +217,7 @@ class MockitoScalazTest extends AnyWordSpec with Matchers with MockitoSugar with
       doReturnF[F, ValueClass](ValueClass("mocked!")).when(aMock).returnsEitherT("hello")
 
       whenReady(aMock.returnsEitherT("bye").run)(_.toEither.left.value shouldBe Error("error"))
-      whenReady(aMock.returnsEitherT("hello").run)(_.toEither.right.value shouldBe ValueClass("mocked!"))
+      whenReady(aMock.returnsEitherT("hello").run)(_.toEither.value shouldBe ValueClass("mocked!"))
     }
 
     "work with OptionT" in {
@@ -257,9 +257,9 @@ class MockitoScalazTest extends AnyWordSpec with Matchers with MockitoSugar with
         .returnsFutureEither("hola")
       doAnswerFG[Future, Option, Int, Boolean, String]((i: Int, b: Boolean) => s"$i, $b").when(aMock).returnsFutureOptionFrom(42, true)
 
-      whenReady(aMock.returnsFutureEither("hello"))(_.right.value shouldBe ValueClass("mocked!"))
-      whenReady(aMock.returnsFutureEither("hi"))(_.right.value shouldBe ValueClass("hi mocked!"))
-      whenReady(aMock.returnsFutureEither("hola"))(_.right.value shouldBe ValueClass("hola invocation mocked!"))
+      whenReady(aMock.returnsFutureEither("hello"))(_.value shouldBe ValueClass("mocked!"))
+      whenReady(aMock.returnsFutureEither("hi"))(_.value shouldBe ValueClass("hi mocked!"))
+      whenReady(aMock.returnsFutureEither("hola"))(_.value shouldBe ValueClass("hola invocation mocked!"))
       whenReady(aMock.returnsFutureOptionFrom(42, true))(_.value shouldBe "42, true")
     }
   }

--- a/specs2/src/test/scala/org/mockito/specs2/MockitoScalaNewSyntaxSpec.scala
+++ b/specs2/src/test/scala/org/mockito/specs2/MockitoScalaNewSyntaxSpec.scala
@@ -678,7 +678,7 @@ The Mockito trait is reusable in other contexts
 
     def List[T](a: List[T]): Unit
     def Set[T](a: Set[T]): Unit
-    def Traversable[T](a: Traversable[T]): Unit
+    def Iterable[T](a: Iterable[T]): Unit
     def Map[K, V](a: Map[K, V]): Unit
 
     def varargs[T](ts: T*): Unit
@@ -700,7 +700,7 @@ The Mockito trait is reusable in other contexts
 
     m.List(List[Int]())
     m.Set(Set[Int]())
-    m.Traversable(List[Int]())
+    m.Iterable(List[Int]())
     m.Map(Map[Int, String]())
 
     m.varargs(1, 2)
@@ -713,7 +713,7 @@ The Mockito trait is reusable in other contexts
       m.javaMap(*) was called
       m.List(*) was called
       m.Set(*) was called
-      m.Traversable(*) was called
+      m.Iterable(*) was called
       m.Map(*) was called
       m.varargs(*, *) was called
       m.array(*) was called

--- a/specs2/src/test/scala/org/mockito/specs2/MockitoScalaSpec.scala
+++ b/specs2/src/test/scala/org/mockito/specs2/MockitoScalaSpec.scala
@@ -677,7 +677,7 @@ The Mockito trait is reusable in other contexts
 
     def List[T](a: List[T]): Unit
     def Set[T](a: Set[T]): Unit
-    def Traversable[T](a: Traversable[T]): Unit
+    def Iterable[T](a: Iterable[T]): Unit
     def Map[K, V](a: Map[K, V]): Unit
 
     def varargs[T](ts: T*): Unit
@@ -699,7 +699,7 @@ The Mockito trait is reusable in other contexts
 
     m.List(List[Int]())
     m.Set(Set[Int]())
-    m.Traversable(List[Int]())
+    m.Iterable(List[Int]())
     m.Map(Map[Int, String]())
 
     m.varargs(1, 2)
@@ -711,7 +711,7 @@ The Mockito trait is reusable in other contexts
     one(m).javaMap(*) andThen
     one(m).List(*) andThen
     one(m).Set(*) andThen
-    one(m).Traversable(*) andThen
+    one(m).Iterable(*) andThen
     one(m).Map(*) andThen
     one(m).varargs(*, *) andThen
     one(m).array(*)


### PR DESCRIPTION
@TimvdLippe 
i would like to add support for Scala 3, but i also like baby steps, so this is one of the steps towards Scala 3 (and cleaner build). The only usages of deprecated elements left (and suppressed) are from mockito-core, like 
```java
    /**
     * @deprecated Not used by Mockito but by mockito-scala
     */
    @Deprecated
    public RealMethod getRealMethod() {
        return realMethod;
    }
```
all other deprecated warnings are fixed and compiler will not let add new ones without explicitly suppressing them