### PR TITLE
Make tests scala 3 friendlier

### DIFF
--- a/cats/src/test/scala/org/mockito/cats/DoSomethingCatsTest.scala
+++ b/cats/src/test/scala/org/mockito/cats/DoSomethingCatsTest.scala
@@ -1,8 +1,7 @@
 package org.mockito.cats
 
-import cats.implicits._
 import org.mockito.invocation.InvocationOnMock
-import org.mockito.{ ArgumentMatchersSugar, IdiomaticMockito }
+import org.mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ EitherValues, OptionValues }
 

--- a/cats/src/test/scala/org/mockito/cats/IdiomaticMockitoCatsTest.scala
+++ b/cats/src/test/scala/org/mockito/cats/IdiomaticMockitoCatsTest.scala
@@ -1,9 +1,8 @@
 package org.mockito.cats
 
 import cats.Eq
-import cats.implicits._
 import org.mockito.invocation.InvocationOnMock
-import org.mockito.{ ArgumentMatchersSugar, IdiomaticMockito }
+import org.mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ EitherValues, OptionValues }
 

--- a/cats/src/test/scala/org/mockito/cats/MockitoCatsTest.scala
+++ b/cats/src/test/scala/org/mockito/cats/MockitoCatsTest.scala
@@ -2,9 +2,8 @@ package org.mockito.cats
 
 import cats.Eq
 import cats.data.{ EitherT, OptionT }
-import cats.implicits._
 import org.mockito.invocation.InvocationOnMock
-import org.mockito.{ ArgumentMatchersSugar, MockitoSugar }
+import org.mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ EitherValues, OptionValues }
 
@@ -251,7 +250,7 @@ class MockitoCatsTest extends AnyWordSpec with Matchers with MockitoSugar with A
 
       doAnswerFG[Future, ErrorOr, ValueClass](ValueClass("mocked!")).when(aMock).returnsFutureEither("hello")
       doAnswerFG[Future, ErrorOr, String, ValueClass]((s: String) => ValueClass(s + " mocked!")).when(aMock).returnsFutureEither("hi")
-      doAnswerFG[Future, ErrorOr, InvocationOnMock, ValueClass] { i: InvocationOnMock => ValueClass(i.arg[String](0) + " invocation mocked!") }
+      doAnswerFG[Future, ErrorOr, InvocationOnMock, ValueClass]((i: InvocationOnMock) => ValueClass(i.arg[String](0) + " invocation mocked!"))
         .when(aMock)
         .returnsFutureEither("hola")
       doAnswerFG[Future, Option, Int, Boolean, String]((i: Int, b: Boolean) => s"$i, $b").when(aMock).returnsFutureOptionFrom(42, true)

--- a/scalatest/src/test/scala/user/org/mockito/DoSomethingTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/DoSomethingTest.scala
@@ -3,7 +3,7 @@ package user.org.mockito
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.mockito.invocation.InvocationOnMock
-import org.mockito.{ ArgumentMatchersSugar, MockitoSugar }
+import org.mockito._
 import user.org.mockito.matchers.{ ValueCaseClassInt, ValueCaseClassString, ValueClass }
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/scalatest/src/test/scala/user/org/mockito/IdiomaticStubbingTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/IdiomaticStubbingTest.scala
@@ -3,7 +3,7 @@ package user.org.mockito
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.mockito.invocation.InvocationOnMock
-import org.mockito.{ ArgumentMatchersSugar, IdiomaticStubbing }
+import org.mockito._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import user.org.mockito.matchers.{ ValueCaseClassInt, ValueCaseClassString, ValueClass }

--- a/scalatest/src/test/scala/user/org/mockito/MalformedClassError.scala
+++ b/scalatest/src/test/scala/user/org/mockito/MalformedClassError.scala
@@ -25,8 +25,8 @@ class MalformedClassError extends AnyWordSpecLike with Matchers with IdiomaticMo
 object MalformedClassError {
   sealed trait Permissions
   object Permissions {
-    final case object Allowed extends Permissions
-    final case object Denied  extends Permissions
+    case object Allowed extends Permissions
+    case object Denied  extends Permissions
   }
   type Allowed = Permissions.Allowed.type
 

--- a/scalatest/src/test/scala/user/org/mockito/MockitoSugarTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/MockitoSugarTest.scala
@@ -8,14 +8,13 @@ import org.mockito.exceptions.misusing.WrongTypeOfReturnValue
 import org.mockito.exceptions.verification.{ ArgumentsAreDifferent, WantedButNotInvoked }
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.{ CallsRealMethods, DefaultAnswer, ScalaFirstStubbing }
-import org.mockito.{ ArgumentMatchersSugar, MockitoSugar }
+import org.mockito._
 import org.scalactic.Prettifier
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{ EitherValues, OptionValues }
 import user.org.mockito.matchers.{ ValueCaseClassInt, ValueCaseClassString, ValueClass }
 import user.org.mockito.model.JavaFoo
 
-import scala.reflect.io.AbstractFile
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -317,14 +316,6 @@ class MockitoSugarTest extends AnyWordSpec with MockitoSugar with Matchers with 
       org.takesManyValueClasses(new ValueClass("1"), ValueCaseClassInt(2), ValueCaseClassString("3")) shouldBe "ValueClass(1)-ValueCaseClassInt(2)-ValueCaseClassString(3)"
     }
 
-    "not mock final methods" in {
-      val abstractFile = mock[AbstractFile]
-
-      when(abstractFile.path) thenReturn "sammy.scala"
-
-      abstractFile.path shouldBe "sammy.scala"
-    }
-
     "be serialisable" in {
       val list = mock[java.util.List[String]](withSettings.name("list1").serializable())
       when(list.get(eqTo(3))) thenAnswer "mocked"
@@ -353,7 +344,7 @@ class MockitoSugarTest extends AnyWordSpec with MockitoSugar with Matchers with 
 
       aMock.bar shouldBe "hola"
 
-      val ex = the[WrongTypeOfReturnValue] thrownBy (aMock.returnBar shouldBe "hola")
+      val ex = the[WrongTypeOfReturnValue] thrownBy aMock.returnBar
       ex.getMessage should include("Default answer returned a result with the wrong type")
     }
 

--- a/scalatest/src/test/scala/user/org/mockito/scalatest/IdiomaticMockitoFixtureClassTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/scalatest/IdiomaticMockitoFixtureClassTest.scala
@@ -20,7 +20,7 @@ class IdiomaticMockitoFixtureClassTest extends flatspec.FixtureAnyFlatSpec with 
     withFixture(test.toNoArgTest(theFixture))
   }
 
-  "Mockito" should "verifyNoMoreInteractions fixture objects" in { f: FixtureParam =>
+  "Mockito" should "verifyNoMoreInteractions fixture objects" in { (f: FixtureParam) =>
     "mocked" willBe returned by f.foo.bar("pepe")
 
     f.foo wasNever called
@@ -32,7 +32,7 @@ class IdiomaticMockitoFixtureClassTest extends flatspec.FixtureAnyFlatSpec with 
     }
   }
 
-  "Mockito" should "verify no calls on fixture objects methods" in { f: FixtureParam =>
+  "Mockito" should "verify no calls on fixture objects methods" in { (f: FixtureParam) =>
     "mocked" willBe returned by f.foo.bar("pepe")
     "mocked" willBe returned by f.foo.baz
 

--- a/scalatest/src/test/scala/user/org/mockito/scalatest/IdiomaticMockitoWithExpectFixtureClassTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/scalatest/IdiomaticMockitoWithExpectFixtureClassTest.scala
@@ -22,7 +22,7 @@ class IdiomaticMockitoWithExpectFixtureClassTest extends flatspec.FixtureAnyFlat
     super.withFixture(test.toNoArgTest(theFixture))
   }
 
-  "expect no calls TO" should "verify no calls on fixture objects methods" in { f: FixtureParam =>
+  "expect no calls TO" should "verify no calls on fixture objects methods" in { (f: FixtureParam) =>
     "mocked" willBe returned by f.foo.bar("pepe")
     "mocked" willBe returned by f.foo.baz
 
@@ -37,7 +37,7 @@ class IdiomaticMockitoWithExpectFixtureClassTest extends flatspec.FixtureAnyFlat
     }
   }
 
-  "expect no calls ON" should "verify no calls on a mock inside a fixture object" in { f: FixtureParam =>
+  "expect no calls ON" should "verify no calls on a mock inside a fixture object" in { (f: FixtureParam) =>
     f.foo.bar("pepe") returns "mocked"
 
     expect no calls on f.foo
@@ -49,7 +49,7 @@ class IdiomaticMockitoWithExpectFixtureClassTest extends flatspec.FixtureAnyFlat
     }
   }
 
-  it should "prevent usage of 'no calls to' when 'no calls on' is intended" in { f: FixtureParam =>
+  it should "prevent usage of 'no calls to' when 'no calls on' is intended" in { (f: FixtureParam) =>
     the[MissingMethodInvocationException] thrownBy {
       expect no calls to f.foo
     } should have message
@@ -62,7 +62,7 @@ class IdiomaticMockitoWithExpectFixtureClassTest extends flatspec.FixtureAnyFlat
         |""".stripMargin
   }
 
-  "expect noMore calls on" should "verify no more calls on a mock inside a fixture object" in { f: FixtureParam =>
+  "expect noMore calls on" should "verify no more calls on a mock inside a fixture object" in { (f: FixtureParam) =>
     f.foo.bar("pepe") returns "mocked"
 
     f.foo.bar("pepe") shouldBe "mocked"

--- a/scalaz/src/test/scala/org/mockito/scalaz/DoSomethingScalazTest.scala
+++ b/scalaz/src/test/scala/org/mockito/scalaz/DoSomethingScalazTest.scala
@@ -1,6 +1,6 @@
 package org.mockito.scalaz
 
-import org.mockito.{ ArgumentMatchersSugar, IdiomaticMockito }
+import org.mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ EitherValues, OptionValues }
 import _root_.scalaz._

--- a/scalaz/src/test/scala/org/mockito/scalaz/IdiomaticMockitoScalazTest.scala
+++ b/scalaz/src/test/scala/org/mockito/scalaz/IdiomaticMockitoScalazTest.scala
@@ -1,11 +1,11 @@
 package org.mockito.scalaz
 
 import _root_.scalaz._
+import Scalaz._
 import org.mockito.invocation.InvocationOnMock
-import org.mockito.{ ArgumentMatchersSugar, IdiomaticMockito }
+import org.mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ EitherValues, OptionValues }
-import scalaz.Scalaz._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ Future, Promise }

--- a/scalaz/src/test/scala/org/mockito/scalaz/MockitoScalazTest.scala
+++ b/scalaz/src/test/scala/org/mockito/scalaz/MockitoScalazTest.scala
@@ -3,7 +3,7 @@ package org.mockito.scalaz
 import _root_.scalaz._
 import Scalaz._
 import org.mockito.invocation.InvocationOnMock
-import org.mockito.{ ArgumentMatchersSugar, MockitoSugar }
+import org.mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ EitherValues, OptionValues }
 
@@ -252,7 +252,7 @@ class MockitoScalazTest extends AnyWordSpec with Matchers with MockitoSugar with
 
       doAnswerFG[Future, ErrorOr, ValueClass](ValueClass("mocked!")).when(aMock).returnsFutureEither("hello")
       doAnswerFG[Future, ErrorOr, String, ValueClass]((s: String) => ValueClass(s + " mocked!")).when(aMock).returnsFutureEither("hi")
-      doAnswerFG[Future, ErrorOr, InvocationOnMock, ValueClass] { i: InvocationOnMock => ValueClass(i.arg[String](0) + " invocation mocked!") }
+      doAnswerFG[Future, ErrorOr, InvocationOnMock, ValueClass]((i: InvocationOnMock) => ValueClass(i.arg[String](0) + " invocation mocked!"))
         .when(aMock)
         .returnsFutureEither("hola")
       doAnswerFG[Future, Option, Int, Boolean, String]((i: Int, b: Boolean) => s"$i, $b").when(aMock).returnsFutureOptionFrom(42, true)

--- a/specs2/src/test/scala/org/mockito/specs2/MockitoScalaNewSyntaxSpec.scala
+++ b/specs2/src/test/scala/org/mockito/specs2/MockitoScalaNewSyntaxSpec.scala
@@ -4,7 +4,7 @@ import java.io.{ File, FileOutputStream, ObjectOutputStream }
 import java.util
 import org.hamcrest.core.IsNull
 import org.mockito.IdiomaticMockitoBase.Times
-import org.mockito.VerifyOrder
+import org.mockito.{ VerifyInOrder, VerifyOrder }
 import org.mockito.captor.ArgCaptor
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.DefaultAnswer
@@ -554,7 +554,7 @@ The Mockito trait is reusable in other contexts
     list1.get(0)
     list1.get(1)
 
-    implicit val order = inOrder(list1)
+    implicit val order: VerifyInOrder = inOrder(list1)
 
     val result = list1.get(1).was(called) andThen list1.get(0).was(called)
 
@@ -567,7 +567,7 @@ The Mockito trait is reusable in other contexts
     list1.get(0)
     list1.get(1)
 
-    implicit val order = inOrder(list1)
+    implicit val order: VerifyInOrder = inOrder(list1)
 
     var result: Result = success
 
@@ -593,8 +593,8 @@ The Mockito trait is reusable in other contexts
 
     list1.get(0); list1.size; list1.get(0); list1.size
 
-    implicit val order = inOrder(list1)
-    val result         = got {
+    implicit val order: VerifyInOrder = inOrder(list1)
+    val result                        = got {
       list1.get(0) was called
       list1.size() was called
       list1.get(0) wasNever called
@@ -608,13 +608,13 @@ The Mockito trait is reusable in other contexts
 
   def callbacks1 = {
     val list = mock[java.util.List[String]]("list")
-    list.get(*) answers { i: Int => s"The parameter is ${i.toString}" }
+    list.get(*) answers { (i: Int) => s"The parameter is ${i.toString}" }
     list.get(2) must_== "The parameter is 2"
   }
 
   def callbacks2 = {
     val list = mock[java.util.List[String]]("list")
-    list.get(*) answers { i: Int => (i + 1).toString }
+    list.get(*) answers { (i: Int) => (i + 1).toString }
     list.get(1) must_== "2"
     list.get(5) must_== "6"
   }

--- a/specs2/src/test/scala/org/mockito/specs2/MockitoScalaSpec.scala
+++ b/specs2/src/test/scala/org/mockito/specs2/MockitoScalaSpec.scala
@@ -3,7 +3,7 @@ package org.mockito.specs2
 import java.io.{ File, FileOutputStream, ObjectOutputStream }
 import java.util
 import org.hamcrest.core.IsNull
-import org.mockito.VerifyOrder
+import org.mockito.{ VerifyInOrder, VerifyOrder }
 import org.mockito.captor.ArgCaptor
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.DefaultAnswer
@@ -525,7 +525,7 @@ The Mockito trait is reusable in other contexts
     list1.get(0)
     list2.get(0)
 
-    implicit val order = inOrder(list1, list2)
+    implicit val order: VerifyInOrder = inOrder(list1, list2)
     (there was one(list1).get(0) andThen
       one(list2).get(0)).message must_== "The mock was called as expected"
   }
@@ -541,7 +541,7 @@ The Mockito trait is reusable in other contexts
     list1.get(0)
     list2.get(0)
 
-    implicit val order = inOrder(ignoreStubs(list1, list2))
+    implicit val order: VerifyInOrder = inOrder(ignoreStubs(list1, list2))
     (there was one(list1).get(0) andThen
       one(list2).get(0)).message must_== "The mock was called as expected"
   }
@@ -552,7 +552,7 @@ The Mockito trait is reusable in other contexts
     list1.get(0)
     list1.get(1)
 
-    implicit val order = inOrder(list1)
+    implicit val order: VerifyInOrder = inOrder(list1)
 
     val result = there was one(list1).get(1) andThen
       one(list1).get(0)
@@ -566,7 +566,7 @@ The Mockito trait is reusable in other contexts
     list1.get(0)
     list1.get(1)
 
-    implicit val order = inOrder(list1)
+    implicit val order: VerifyInOrder = inOrder(list1)
 
     var result: Result = success
 
@@ -584,7 +584,7 @@ The Mockito trait is reusable in other contexts
     list1.get(0)
     list2.get(0)
 
-    implicit val order = inOrder(list1, list2)
+    implicit val order: VerifyInOrder = inOrder(list1, list2)
     (there was one(list2).get(0) andThen
       one(list1).get(0)).message must startWith("The mock was not called as expected")
   }
@@ -594,8 +594,8 @@ The Mockito trait is reusable in other contexts
 
     list1.get(0); list1.size; list1.get(0); list1.size
 
-    implicit val order = inOrder(list1)
-    val result         = there was one(list1).get(0) andThen
+    implicit val order: VerifyInOrder = inOrder(list1)
+    val result                        = there was one(list1).get(0) andThen
       one(list1).size() andThen
       no(list1).get(0) andThen
       one(list1).size()
@@ -607,13 +607,13 @@ The Mockito trait is reusable in other contexts
 
   def callbacks1 = {
     val list = mock[java.util.List[String]]("list")
-    list.get(*) answers { i: Int => "The parameter is " + i.toString }
+    list.get(*) answers { (i: Int) => "The parameter is " + i.toString }
     list.get(2) must_== "The parameter is 2"
   }
 
   def callbacks2 = {
     val list = mock[java.util.List[String]]("list")
-    list.get(*) answers { i: Int => (i + 1).toString }
+    list.get(*) answers { (i: Int) => (i + 1).toString }
     list.get(1) must_== "2"
     list.get(5) must_== "6"
   }


### PR DESCRIPTION
These are low hanging fruits on the path to Scala 3. Not 100% sure we gonna get there without loses, but I hope so :)

One minor concern is dropped test using `scala.reflect.io.AbstractFile` (which doesn't exist in Scala 3) and named `not mock final methods` but that method `path` is not final, so I'm not sure what exactly that test was doing.
Maybe @ultrasecreth can shed some light.