### PR TITLE
Add "-Xsource:3" compiler option

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -4,6 +4,7 @@ runner.dialect = scala213source3
 docstrings.style = asterisk
 maxColumn = 180
 rewrite.rules = [RedundantBraces, RedundantParens, SortImports]
+rewrite.scala3.convertToNewSyntax = true
 spaces.inImportCurlyBraces = true
 indentOperator.preset = spray
 

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,11 +1,10 @@
 style = defaultWithAlign
 
-runner.dialect = scala213
+runner.dialect = scala213source3
 docstrings.style = asterisk
 maxColumn = 180
 rewrite.rules = [RedundantBraces, RedundantParens, SortImports]
 spaces.inImportCurlyBraces = true
 indentOperator.preset = spray
 
-version=3.9.9
-
+version = 3.9.9

--- a/build.sbt
+++ b/build.sbt
@@ -23,13 +23,12 @@ lazy val commonSettings =
       "-encoding",
       "UTF-8",
       "-Xfatal-warnings",
+      "-Xsource:3",
 //      "-Xmacro-settings:mockito-print-when,mockito-print-do-something,mockito-print-verify,mockito-print-expect,mockito-print-captor,mockito-print-matcher,mockito-print-extractor,mockito-print-wrapper,mockito-print-lenient",
       "-language:reflectiveCalls,implicitConversions,experimental.macros,higherKinds"
     ),
     scalacOptions ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, 11)) =>
-          Seq("-Xsource:2.12", "-Ypartial-unification")
         case Some((2, 12)) =>
           Seq("-Ypartial-unification", "-Ywarn-unused:locals")
         case Some((2, 13)) =>

--- a/cats/src/main/scala/org/mockito/cats/CatsStubbing.scala
+++ b/cats/src/main/scala/org/mockito/cats/CatsStubbing.scala
@@ -338,7 +338,7 @@ case class CatsStubbing[F[_], T](delegate: OngoingStubbing[F[T]]) {
 //             |""".stripMargin)
 //  }
 
-  def thenFailWith[E](error: E)(implicit F: ApplicativeError[F, _ >: E]): CatsStubbing[F, T] =
+  def thenFailWith[E](error: E)(implicit F: ApplicativeError[F, ? >: E]): CatsStubbing[F, T] =
     delegate thenReturn F.raiseError[T](error)
 
   def getMock[M]: M = delegate.getMock[M]
@@ -688,7 +688,7 @@ case class CatsStubbing2[F[_], G[_], T](delegate: OngoingStubbing[F[G[T]]]) {
 //             |""".stripMargin)
 //  }
 
-  def thenFailWith[E](error: E)(implicit ae: Applicative[F], ag: ApplicativeError[G, _ >: E]): CatsStubbing2[F, G, T] =
+  def thenFailWith[E](error: E)(implicit ae: Applicative[F], ag: ApplicativeError[G, ? >: E]): CatsStubbing2[F, G, T] =
     delegate thenReturn ae.pure(ag.raiseError[T](error))
 
   def getMock[M]: M = delegate.getMock[M]

--- a/cats/src/main/scala/org/mockito/cats/EqToEquality.scala
+++ b/cats/src/main/scala/org/mockito/cats/EqToEquality.scala
@@ -1,7 +1,7 @@
 package org.mockito.cats
 
 import cats.Eq
-import cats.syntax.eq._
+import cats.syntax.eq.*
 import org.scalactic.Equality
 
 class EqToEquality[T: Eq] extends Equality[T] {

--- a/cats/src/main/scala/org/mockito/cats/IdiomaticMockitoCats.scala
+++ b/cats/src/main/scala/org/mockito/cats/IdiomaticMockitoCats.scala
@@ -1,13 +1,13 @@
 package org.mockito.cats
 
 import cats.{ Applicative, ApplicativeError, Eq }
-import org.mockito._
+import org.mockito.*
 import org.scalactic.Equality
 
 import scala.reflect.ClassTag
 
 trait IdiomaticMockitoCats extends ScalacticSerialisableHack {
-  import org.mockito.cats.IdiomaticMockitoCats._
+  import org.mockito.cats.IdiomaticMockitoCats.*
 
   implicit class StubbingOpsCats[F[_], T](stubbing: F[T]) {
     def shouldReturnF: ReturnActions[F, T] = macro WhenMacro.shouldReturn[T]
@@ -128,12 +128,12 @@ object IdiomaticMockitoCats extends IdiomaticMockitoCats {
 
   object Raised
   case class Raised[T]() {
-    def by[F[_], E](stubbing: F[E])(implicit F: ApplicativeError[F, _ >: T]): F[E] = macro DoSomethingMacro.raised[E]
+    def by[F[_], E](stubbing: F[E])(implicit F: ApplicativeError[F, ? >: T]): F[E] = macro DoSomethingMacro.raised[E]
   }
 
   object RaisedG
   case class RaisedG[T]() {
-    def by[F[_], G[_], E](stubbing: F[G[E]])(implicit F: Applicative[F], G: ApplicativeError[G, _ >: T]): F[G[E]] =
+    def by[F[_], G[_], E](stubbing: F[G[E]])(implicit F: Applicative[F], G: ApplicativeError[G, ? >: T]): F[G[E]] =
       macro DoSomethingMacro.raisedG[E]
   }
 
@@ -146,11 +146,11 @@ object IdiomaticMockitoCats extends IdiomaticMockitoCats {
   }
 
   class ThrowActions[F[_], T](os: CatsStubbing[F, T]) {
-    def apply[E](error: E)(implicit ae: ApplicativeError[F, _ >: E]): CatsStubbing[F, T] = os thenFailWith error
+    def apply[E](error: E)(implicit ae: ApplicativeError[F, ? >: E]): CatsStubbing[F, T] = os thenFailWith error
   }
 
   class ThrowActions2[F[_], G[_], T](os: CatsStubbing2[F, G, T]) {
-    def apply[E](error: E)(implicit ae: Applicative[F], ag: ApplicativeError[G, _ >: E]): CatsStubbing2[F, G, T] = os thenFailWith error
+    def apply[E](error: E)(implicit ae: Applicative[F], ag: ApplicativeError[G, ? >: E]): CatsStubbing2[F, G, T] = os thenFailWith error
   }
 
   class AnswerActions[F[_], T](os: CatsStubbing[F, T]) {

--- a/cats/src/main/scala/org/mockito/cats/MockitoCats.scala
+++ b/cats/src/main/scala/org/mockito/cats/MockitoCats.scala
@@ -1,7 +1,7 @@
 package org.mockito.cats
 
 import cats.{ Applicative, ApplicativeError, Eq }
-import org.mockito._
+import org.mockito.*
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Stubber
 import org.scalactic.Equality
@@ -16,25 +16,25 @@ trait MockitoCats extends ScalacticSerialisableHack {
   def doReturnF[F[_]: Applicative, T](toBeReturned: T, toBeReturnedNext: T*): Stubber =
     Mockito.doReturn(
       Applicative[F].pure(toBeReturned),
-      toBeReturnedNext.map(Applicative[F].pure).map(_.asInstanceOf[Object]): _*
+      toBeReturnedNext.map(Applicative[F].pure).map(_.asInstanceOf[Object])*
     )
 
   def doReturnFG[F[_]: Applicative, G[_]: Applicative, T](toBeReturned: T, toBeReturnedNext: T*): Stubber =
     Mockito.doReturn(
       Applicative[F].compose[G].pure(toBeReturned),
-      toBeReturnedNext.map(Applicative[F].compose[G].pure(_)).map(_.asInstanceOf[Object]): _*
+      toBeReturnedNext.map(Applicative[F].compose[G].pure(_)).map(_.asInstanceOf[Object])*
     )
 
   def doFailWith[F[_], E, T](error: E, errors: E*)(implicit ae: ApplicativeError[F, E]): Stubber =
     Mockito.doReturn(
       ae.raiseError[T](error),
-      errors.map(e => ae.raiseError[T](e)).map(_.asInstanceOf[Object]): _*
+      errors.map(e => ae.raiseError[T](e)).map(_.asInstanceOf[Object])*
     )
 
   def doFailWithG[F[_]: Applicative, G[_], E, T](error: E, errors: E*)(implicit ae: ApplicativeError[G, E]): Stubber =
     Mockito.doReturn(
       Applicative[F].pure(ae.raiseError[T](error)),
-      errors.map(e => ae.raiseError[T](e)).map(Applicative[F].pure).map(_.asInstanceOf[Object]): _*
+      errors.map(e => ae.raiseError[T](e)).map(Applicative[F].pure).map(_.asInstanceOf[Object])*
     )
 
   def doAnswerF[F[_]: Applicative, R](l: => R): Stubber =
@@ -42,7 +42,7 @@ trait MockitoCats extends ScalacticSerialisableHack {
       // Store the param so we don't evaluate the by-name twice
       val _l = l
       _l match {
-        case f: Function0[_] => f()
+        case f: Function0[?] => f()
         case _               => _l
       }
     }.andThen(Applicative[F].pure))
@@ -79,7 +79,7 @@ trait MockitoCats extends ScalacticSerialisableHack {
       // Store the param so we don't evaluate the by-name twice
       val _l = l
       _l match {
-        case f: Function0[_] => f()
+        case f: Function0[?] => f()
         case _               => _l
       }
     }.andThen(Applicative[F].compose[G].pure))

--- a/cats/src/main/scala/org/mockito/cats/instances/argumentMatcher.scala
+++ b/cats/src/main/scala/org/mockito/cats/instances/argumentMatcher.scala
@@ -1,8 +1,8 @@
 package org.mockito.cats
 
-import cats._
+import cats.*
 import org.mockito.ArgumentMatcher
-import org.mockito.matchers._
+import org.mockito.matchers.*
 
 trait ArgumentMatcherInstances {
   implicit val argumentMatcherInstance: ContravariantMonoidal[ArgumentMatcher] with MonoidK[ArgumentMatcher] =

--- a/cats/src/test/scala/org/mockito/cats/DoSomethingCatsTest.scala
+++ b/cats/src/test/scala/org/mockito/cats/DoSomethingCatsTest.scala
@@ -1,7 +1,7 @@
 package org.mockito.cats
 
 import org.mockito.invocation.InvocationOnMock
-import org.mockito._
+import org.mockito.*
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ EitherValues, OptionValues }
 

--- a/cats/src/test/scala/org/mockito/cats/IdiomaticMockitoCatsTest.scala
+++ b/cats/src/test/scala/org/mockito/cats/IdiomaticMockitoCatsTest.scala
@@ -2,7 +2,7 @@ package org.mockito.cats
 
 import cats.Eq
 import org.mockito.invocation.InvocationOnMock
-import org.mockito._
+import org.mockito.*
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ EitherValues, OptionValues }
 

--- a/cats/src/test/scala/org/mockito/cats/MockitoCatsTest.scala
+++ b/cats/src/test/scala/org/mockito/cats/MockitoCatsTest.scala
@@ -3,7 +3,7 @@ package org.mockito.cats
 import cats.Eq
 import cats.data.{ EitherT, OptionT }
 import org.mockito.invocation.InvocationOnMock
-import org.mockito._
+import org.mockito.*
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ EitherValues, OptionValues }
 

--- a/cats/src/test/scala/org/mockito/cats/instances/ArgumentMatcherInstancesTest.scala
+++ b/cats/src/test/scala/org/mockito/cats/instances/ArgumentMatcherInstancesTest.scala
@@ -2,12 +2,12 @@ package org.mockito.cats
 package instances
 
 import cats.{ Contravariant, Eq }
-import cats.implicits._
-import cats.laws.discipline._
-import cats.laws.discipline.arbitrary._
-import cats.laws.discipline.eq._
+import cats.implicits.*
+import cats.laws.discipline.*
+import cats.laws.discipline.arbitrary.*
+import cats.laws.discipline.eq.*
 import org.mockito.{ ArgumentMatcher, ArgumentMatchers, ArgumentMatchersSugar, IdiomaticMockito }
-import org.mockito.internal.matchers._
+import org.mockito.internal.matchers.*
 import org.mockito.matchers.{ EqTo, Generators }
 import org.scalacheck.Arbitrary
 import org.scalatest.matchers.should.Matchers
@@ -16,7 +16,7 @@ import org.scalatest.prop.Configuration
 import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 
 class ArgumentMatcherInstancesTest extends AnyFunSuiteLike with FunSuiteDiscipline with Configuration with ArgumentMatchersSugar with IdiomaticMockito with Matchers {
-  import Generators._
+  import Generators.*
 
   implicit def eqArgumentMatcherExhaustive[A: ExhaustiveCheck]: Eq[ArgumentMatcher[A]] =
     Eq.instance((f, g) => ExhaustiveCheck[A].allValues.forall(a => f.matches(a) == g.matches(a)))

--- a/common/src/main/scala-2.12/org/mockito/internal/handler/package.scala
+++ b/common/src/main/scala-2.12/org/mockito/internal/handler/package.scala
@@ -5,7 +5,7 @@ import scala.collection.mutable
 package object handler {
   def unwrapVarargs(args: Array[Any]): Array[Any] =
     args.lastOption match {
-      case Some(arg: mutable.WrappedArray[_]) => args.init ++ arg
+      case Some(arg: mutable.WrappedArray[?]) => args.init ++ arg
       case _                                  => args
     }
 }

--- a/common/src/main/scala-2.12/org/mockito/stubbing/ReturnsEmptyValues.scala
+++ b/common/src/main/scala-2.12/org/mockito/stubbing/ReturnsEmptyValues.scala
@@ -13,27 +13,27 @@ import scala.util.{ Failure, Try }
 object ReturnsEmptyValues extends DefaultAnswer {
   private val javaEmptyValuesAndPrimitives = new ReturnsMoreEmptyValues
 
-  private[mockito] lazy val emptyValues: Map[Class[_], AnyRef] = Map(
-    classOf[Option[_]]      -> Option.empty,
-    classOf[List[_]]        -> List.empty,
-    classOf[Set[_]]         -> Set.empty,
-    classOf[Seq[_]]         -> Seq.empty,
-    classOf[Iterable[_]]    -> Iterable.empty,
-    classOf[Traversable[_]] -> Traversable.empty,
-    classOf[IndexedSeq[_]]  -> IndexedSeq.empty,
-    classOf[Iterator[_]]    -> Iterator.empty,
-    classOf[Stream[_]]      -> Stream.empty,
-    classOf[Vector[_]]      -> Vector.empty,
-    classOf[Try[_]]         -> Failure(new MockitoException("Auto stub provided by mockito-scala")),
-    classOf[Future[_]]      -> Future.failed(new MockitoException("Auto stub provided by mockito-scala")),
+  private[mockito] lazy val emptyValues: Map[Class[?], AnyRef] = Map(
+    classOf[Option[?]]      -> Option.empty,
+    classOf[List[?]]        -> List.empty,
+    classOf[Set[?]]         -> Set.empty,
+    classOf[Seq[?]]         -> Seq.empty,
+    classOf[Iterable[?]]    -> Iterable.empty,
+    classOf[Traversable[?]] -> Traversable.empty,
+    classOf[IndexedSeq[?]]  -> IndexedSeq.empty,
+    classOf[Iterator[?]]    -> Iterator.empty,
+    classOf[Stream[?]]      -> Stream.empty,
+    classOf[Vector[?]]      -> Vector.empty,
+    classOf[Try[?]]         -> Failure(new MockitoException("Auto stub provided by mockito-scala")),
+    classOf[Future[?]]      -> Future.failed(new MockitoException("Auto stub provided by mockito-scala")),
     classOf[BigDecimal]     -> BigDecimal(0),
     classOf[BigInt]         -> BigInt(0),
     classOf[StringBuilder]  -> StringBuilder.newBuilder,
-    classOf[Map[_, _]]      -> Map.empty,
-    classOf[ListBuffer[_]]  -> ListBuffer.empty,
-    classOf[mutable.Seq[_]] -> ListBuffer.empty,
-    classOf[mutable.Set[_]] -> mutable.HashSet.empty,
-    classOf[Either[_, _]]   -> Left("Auto stub provided by mockito-scala")
+    classOf[Map[?, ?]]      -> Map.empty,
+    classOf[ListBuffer[?]]  -> ListBuffer.empty,
+    classOf[mutable.Seq[?]] -> ListBuffer.empty,
+    classOf[mutable.Set[?]] -> mutable.HashSet.empty,
+    classOf[Either[?, ?]]   -> Left("Auto stub provided by mockito-scala")
   )
 
   override def apply(invocation: InvocationOnMock): Option[Any] =

--- a/common/src/main/scala-2.13/org/mockito/internal/handler/package.scala
+++ b/common/src/main/scala-2.13/org/mockito/internal/handler/package.scala
@@ -5,7 +5,7 @@ import scala.collection.immutable.ArraySeq
 package object handler {
   def unwrapVarargs(args: Array[Any]): Array[Any] =
     args.lastOption match {
-      case Some(arg: ArraySeq[_]) => args.init ++ arg
+      case Some(arg: ArraySeq[?]) => args.init ++ arg
       case _                      => args
     }
 }

--- a/common/src/main/scala-2.13/org/mockito/stubbing/ReturnsEmptyValues.scala
+++ b/common/src/main/scala-2.13/org/mockito/stubbing/ReturnsEmptyValues.scala
@@ -13,26 +13,26 @@ import scala.util.{ Failure, Try }
 object ReturnsEmptyValues extends DefaultAnswer {
   private val javaEmptyValuesAndPrimitives = new ReturnsMoreEmptyValues
 
-  private[mockito] lazy val emptyValues: Map[Class[_], AnyRef] = Map(
-    classOf[Option[_]]      -> Option.empty,
-    classOf[List[_]]        -> List.empty,
-    classOf[Set[_]]         -> Set.empty,
-    classOf[Seq[_]]         -> Seq.empty,
-    classOf[Iterable[_]]    -> Iterable.empty,
-    classOf[IndexedSeq[_]]  -> IndexedSeq.empty,
-    classOf[Iterator[_]]    -> Iterator.empty,
-    classOf[LazyList[_]]    -> LazyList.empty,
-    classOf[Vector[_]]      -> Vector.empty,
-    classOf[Try[_]]         -> Failure(new MockitoException("Auto stub provided by mockito-scala")),
-    classOf[Future[_]]      -> Future.failed(new MockitoException("Auto stub provided by mockito-scala")),
+  private[mockito] lazy val emptyValues: Map[Class[?], AnyRef] = Map(
+    classOf[Option[?]]      -> Option.empty,
+    classOf[List[?]]        -> List.empty,
+    classOf[Set[?]]         -> Set.empty,
+    classOf[Seq[?]]         -> Seq.empty,
+    classOf[Iterable[?]]    -> Iterable.empty,
+    classOf[IndexedSeq[?]]  -> IndexedSeq.empty,
+    classOf[Iterator[?]]    -> Iterator.empty,
+    classOf[LazyList[?]]    -> LazyList.empty,
+    classOf[Vector[?]]      -> Vector.empty,
+    classOf[Try[?]]         -> Failure(new MockitoException("Auto stub provided by mockito-scala")),
+    classOf[Future[?]]      -> Future.failed(new MockitoException("Auto stub provided by mockito-scala")),
     classOf[BigDecimal]     -> BigDecimal(0),
     classOf[BigInt]         -> BigInt(0),
     classOf[StringBuilder]  -> new StringBuilder,
-    classOf[Map[_, _]]      -> Map.empty,
-    classOf[ListBuffer[_]]  -> ListBuffer.empty,
-    classOf[mutable.Seq[_]] -> ListBuffer.empty,
-    classOf[mutable.Set[_]] -> mutable.HashSet.empty,
-    classOf[Either[_, _]]   -> Left("Auto stub provided by mockito-scala")
+    classOf[Map[?, ?]]      -> Map.empty,
+    classOf[ListBuffer[?]]  -> ListBuffer.empty,
+    classOf[mutable.Seq[?]] -> ListBuffer.empty,
+    classOf[mutable.Set[?]] -> mutable.HashSet.empty,
+    classOf[Either[?, ?]]   -> Left("Auto stub provided by mockito-scala")
   )
 
   override def apply(invocation: InvocationOnMock): Option[Any] =

--- a/common/src/main/scala/org/mockito/JavaReflectionUtils.scala
+++ b/common/src/main/scala/org/mockito/JavaReflectionUtils.scala
@@ -11,7 +11,7 @@ import scala.util.control.NonFatal
  */
 object JavaReflectionUtils {
 
-  def resolveWithJavaGenerics(invocation: InvocationOnMock): Option[Class[_]] =
+  def resolveWithJavaGenerics(invocation: InvocationOnMock): Option[Class[?]] =
     try Some(GenericsResolver.resolve(invocation.getMock.getClass).`type`(invocation.method.getDeclaringClass).method(invocation.method).resolveReturnClass())
     catch {
       case _: Throwable => None
@@ -20,7 +20,7 @@ object JavaReflectionUtils {
   def setFinalStatic(field: Field, newValue: AnyRef): Unit =
     try {
       // Try to get Unsafe instance (works with both sun.misc.Unsafe and jdk.internal.misc.Unsafe)
-      val unsafeClass: Class[_] =
+      val unsafeClass: Class[?] =
         try
           Class.forName("sun.misc.Unsafe")
         catch {

--- a/common/src/main/scala/org/mockito/MockitoAPI.scala
+++ b/common/src/main/scala/org/mockito/MockitoAPI.scala
@@ -24,11 +24,11 @@ import org.mockito.internal.{ ValueClassExtractor, ValueClassWrapper }
 import org.mockito.invocation.{ Invocation, InvocationContainer, InvocationOnMock, MockHandler }
 import org.mockito.mock.MockCreationSettings
 import org.mockito.quality.Strictness
-import org.mockito.stubbing._
+import org.mockito.stubbing.*
 import org.mockito.verification.{ VerificationAfterDelay, VerificationMode, VerificationWithTimeout }
 import org.scalactic.{ Equality, Prettifier }
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.WeakTypeTag
 
@@ -39,7 +39,7 @@ private[mockito] trait ScalacticSerialisableHack {
 
 private[mockito] trait MockCreator {
   def mock[T <: AnyRef: ClassTag: WeakTypeTag](implicit defaultAnswer: DefaultAnswer, $pt: Prettifier): T
-  def mock[T <: AnyRef: ClassTag: WeakTypeTag](defaultAnswer: Answer[_])(implicit $pt: Prettifier): T =
+  def mock[T <: AnyRef: ClassTag: WeakTypeTag](defaultAnswer: Answer[?])(implicit $pt: Prettifier): T =
     mock[T](DefaultAnswer(defaultAnswer))
   def mock[T <: AnyRef: ClassTag: WeakTypeTag](defaultAnswer: DefaultAnswer)(implicit $pt: Prettifier): T
   def mock[T <: AnyRef: ClassTag: WeakTypeTag](mockSettings: MockSettings)(implicit $pt: Prettifier): T
@@ -102,7 +102,7 @@ private[mockito] trait DoSomething {
       // Store the param so we don't evaluate the by-name twice
       val _l = l
       _l match {
-        case f: Function0[_] => f()
+        case f: Function0[?] => f()
         case _               => _l
       }
     })
@@ -499,14 +499,14 @@ private[mockito] trait MockitoEnhancer extends MockCreator {
     val interfaces = ReflectionUtils.extraInterfaces
 
     val realClass: Class[T] = mockSettings match {
-      case m: MockSettingsImpl[_] if !m.getExtraInterfaces.isEmpty =>
+      case m: MockSettingsImpl[?] if !m.getExtraInterfaces.isEmpty =>
         throw new IllegalArgumentException("If you want to add extra traits to the mock use the syntax mock[MyClass with MyTrait]")
-      case m: MockSettingsImpl[_] if m.getSpiedInstance != null => m.getSpiedInstance.getClass.asInstanceOf[Class[T]]
+      case m: MockSettingsImpl[?] if m.getSpiedInstance != null => m.getSpiedInstance.getClass.asInstanceOf[Class[T]]
       case _                                                    => clazz
     }
 
     val settings =
-      if (interfaces.nonEmpty) mockSettings.extraInterfaces(interfaces: _*)
+      if (interfaces.nonEmpty) mockSettings.extraInterfaces(interfaces*)
       else mockSettings
 
     def createMock(settings: MockCreationSettings[T]): T = {
@@ -517,7 +517,7 @@ private[mockito] trait MockitoEnhancer extends MockCreator {
     }
 
     settings match {
-      case s: MockSettingsImpl[_] =>
+      case s: MockSettingsImpl[?] =>
         val creationSettings = s.build[T](realClass)
         val mock             = createMock(creationSettings)
         mockingProgress.mockingStarted(mock, creationSettings)
@@ -584,7 +584,7 @@ private[mockito] trait MockitoEnhancer extends MockCreator {
         ignoreDefaultArguments(m)
         Mockito.verifyNoMoreInteractions(m)
       case t: Array[AnyRef] =>
-        verifyNoMoreInteractions(t.toIndexedSeq: _*)
+        verifyNoMoreInteractions(t.toIndexedSeq*)
       case _ =>
         throw notAMockPassedToVerifyNoMoreInteractions
     }
@@ -593,7 +593,7 @@ private[mockito] trait MockitoEnhancer extends MockCreator {
   /**
    * Delegates to <code>Mockito.ignoreStubs()</code>, it's only here to expose the full Mockito API
    */
-  def ignoreStubs(mocks: AnyRef*): Array[AnyRef] = Mockito.ignoreStubs(mocks: _*)
+  def ignoreStubs(mocks: AnyRef*): Array[AnyRef] = Mockito.ignoreStubs(mocks*)
 
   /**
    * Creates a "spy" in a way that supports lambdas and anonymous classes as they don't work with the standard spy as they are created as final classes by the compiler
@@ -722,12 +722,12 @@ private[mockito] trait Rest extends MockitoEnhancer with DoSomething with Verifi
   /**
    * Delegates to <code>Mockito.verifyZeroInteractions()</code>, it's only here to expose the full Mockito API
    */
-  def verifyZeroInteractions(mocks: AnyRef*): Unit = Mockito.verifyNoInteractions(mocks: _*)
+  def verifyZeroInteractions(mocks: AnyRef*): Unit = Mockito.verifyNoInteractions(mocks*)
 
   /**
    * Delegates to <code>Mockito.inOrder()</code>, it's only here to expose the full Mockito API
    */
-  def inOrder(mocks: AnyRef*): InOrder = Mockito.inOrder(mocks: _*)
+  def inOrder(mocks: AnyRef*): InOrder = Mockito.inOrder(mocks*)
 
   /**
    * Delegates to <code>Mockito.verify()</code>, it's only here to expose the full Mockito API

--- a/common/src/main/scala/org/mockito/ReflectionUtils.scala
+++ b/common/src/main/scala/org/mockito/ReflectionUtils.scala
@@ -2,16 +2,16 @@ package org.mockito
 
 import org.mockito.JavaReflectionUtils.resolveWithJavaGenerics
 import org.mockito.invocation.InvocationOnMock
-import org.scalactic.TripleEquals._
+import org.scalactic.TripleEquals.*
 
 import java.lang.reflect.Method
 import scala.reflect.ClassTag
 import scala.reflect.internal.Symbols
-import scala.util.{ Try => uTry }
+import scala.util.Try as uTry
 
 object ReflectionUtils {
-  import scala.reflect.runtime.{ universe => ru }
-  import ru._
+  import scala.reflect.runtime.universe as ru
+  import ru.*
 
   implicit def symbolToMethodSymbol(sym: Symbol): Symbols#MethodSymbol = sym.asInstanceOf[Symbols#MethodSymbol]
 
@@ -20,7 +20,7 @@ object ReflectionUtils {
     def methodToJava(sym: Symbols#MethodSymbol): Method
   }]
 
-  private[mockito] def returnType(invocation: InvocationOnMock): Class[_] = {
+  private[mockito] def returnType(invocation: InvocationOnMock): Class[?] = {
     val javaReturnType = invocation.method.getReturnType
 
     if (javaReturnType == classOf[Object])
@@ -33,7 +33,7 @@ object ReflectionUtils {
   private[mockito] def returnsValueClass(invocation: InvocationOnMock): Boolean =
     findTypeSymbol(invocation).exists(_.returnType.typeSymbol.isDerivedValueClass)
 
-  private def resolveWithScalaGenerics(invocation: InvocationOnMock): Option[Class[_]] =
+  private def resolveWithScalaGenerics(invocation: InvocationOnMock): Option[Class[?]] =
     uTry {
       findTypeSymbol(invocation)
         .filter(_.returnType.typeSymbol.isClass)
@@ -54,20 +54,20 @@ object ReflectionUtils {
 
   private def isNonConstructorMethod(d: ru.Symbol): Boolean = d.isMethod && !d.isConstructor
 
-  def extraInterfaces[T](implicit $wtt: WeakTypeTag[T], $ct: ClassTag[T]): List[Class[_]] =
+  def extraInterfaces[T](implicit $wtt: WeakTypeTag[T], $ct: ClassTag[T]): List[Class[?]] =
     uTry {
       val cls = clazz($ct)
       $wtt.tpe match {
         case RefinedType(types, _) =>
           types.map($wtt.mirror.runtimeClass).collect {
-            case c: Class[_] if c.isInterface && c != cls => c
+            case c: Class[?] if c.isInterface && c != cls => c
           }
         case _ => List.empty
       }
     }.toOption
       .getOrElse(List.empty)
 
-  def methodsWithLazyOrVarArgs(classes: Seq[Class[_]]): Seq[(Method, Set[Int])] =
+  def methodsWithLazyOrVarArgs(classes: Seq[Class[?]]): Seq[(Method, Set[Int])] =
     classes.flatMap { clazz =>
       uTry {
         mirror

--- a/common/src/main/scala/org/mockito/internal/handler/ScalaMockHandler.scala
+++ b/common/src/main/scala/org/mockito/internal/handler/ScalaMockHandler.scala
@@ -4,18 +4,18 @@ package internal.handler
 import java.lang.reflect.Method
 import java.util.regex.Pattern
 import org.mockito.ReflectionUtils.methodsWithLazyOrVarArgs
-import org.mockito.internal.handler.ScalaMockHandler._
-import org.mockito.internal.invocation._
+import org.mockito.internal.handler.ScalaMockHandler.*
+import org.mockito.internal.invocation.*
 import org.mockito.internal.progress.ThreadSafeMockingProgress.mockingProgress
 import org.mockito.invocation.{ Invocation, MockHandler }
 import org.mockito.matchers.EqTo
 import org.mockito.mock.MockCreationSettings
 import org.scalactic.Prettifier
-import org.scalactic.TripleEquals._
+import org.scalactic.TripleEquals.*
 
 import scala.annotation.nowarn
-import scala.collection.compat._
-import scala.jdk.CollectionConverters._
+import scala.collection.compat.*
+import scala.jdk.CollectionConverters.*
 
 class ScalaMockHandler[T](mockSettings: MockCreationSettings[T], methodsToProcess: Seq[(Method, Set[Int])])(implicit $pt: Prettifier) extends MockHandlerImpl[T](mockSettings) {
   override def handle(invocation: Invocation): AnyRef =
@@ -47,12 +47,12 @@ class ScalaMockHandler[T](mockSettings: MockCreationSettings[T], methodsToProces
           val matchers                                   = argumentMatcherStorage.pullLocalizedMatchers().asScala.iterator
           val matchersWereUsed                           = matchers.nonEmpty
           def reportMatcher(): Unit                      = if (matchers.nonEmpty) argumentMatcherStorage.reportMatcher(matchers.next().getMatcher)
-          def reportMatchers(varargs: Iterable[_]): Unit =
+          def reportMatchers(varargs: Iterable[?]): Unit =
             if (matchersWereUsed && varargs.nonEmpty) {
               def reportAsEqTo(): Unit = varargs.map(EqTo(_)).foreach(argumentMatcherStorage.reportMatcher(_))
               val matcher              = matchers.next().getMatcher
               matcher match {
-                case EqTo(value: Array[_]) if varargs.iterator.sameElements(value.iterator) => reportAsEqTo()
+                case EqTo(value: Array[?]) if varargs.iterator.sameElements(value.iterator) => reportAsEqTo()
                 case EqTo(value) if varargs == value                                        => reportAsEqTo()
                 case other                                                                  =>
                   argumentMatcherStorage.reportMatcher(other)
@@ -61,12 +61,12 @@ class ScalaMockHandler[T](mockSettings: MockCreationSettings[T], methodsToProces
             }
 
           args.zipWithIndex.flatMap {
-            case (arg: Function0[_], idx) if indices.contains(idx) =>
+            case (arg: Function0[?], idx) if indices.contains(idx) =>
               List(arg())
-            case (arg: Iterable[_], idx) if indices.contains(idx) =>
+            case (arg: Iterable[?], idx) if indices.contains(idx) =>
               reportMatchers(arg)
               arg
-            case (arg: Array[_], idx) if indices.contains(idx) =>
+            case (arg: Array[?], idx) if indices.contains(idx) =>
               val argList = arg.toList
               reportMatchers(arg)
               argList

--- a/common/src/main/scala/org/mockito/internal/invocation/ScalaInvocation.scala
+++ b/common/src/main/scala/org/mockito/internal/invocation/ScalaInvocation.scala
@@ -13,7 +13,7 @@ import org.mockito.invocation.{ Invocation, Location, StubInfo }
 import org.mockito.matchers.EqTo
 import org.scalactic.Prettifier
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 class ScalaInvocation(
     val mockRef: MockReference[AnyRef],
@@ -36,7 +36,7 @@ class ScalaInvocation(
   override def getSequenceNumber: Int                         = sequenceNumber
   override def getLocation: Location                          = location
   override def getRawArguments: Array[AnyRef]                 = rawArguments
-  override def getRawReturnType: Class[_]                     = mockitoMethod.getReturnType
+  override def getRawReturnType: Class[?]                     = mockitoMethod.getReturnType
   override def markVerified(): Unit                           = verified = true
   override def stubInfo(): StubInfo                           = _stubInfo
   override def markStubbed(stubInfo: StubInfo): Unit          = _stubInfo = stubInfo
@@ -63,6 +63,6 @@ class ScalaInvocation(
     state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
   }
   override def toString: String                                      = new PrintSettings().print(getArgumentsAsMatchers, this)
-  override def getArgumentsAsMatchers: util.List[ArgumentMatcher[_]] =
-    arguments.map(EqTo(_)(serialisableEquality[AnyRef], ValueClassExtractor.instance[AnyRef], $pt): ArgumentMatcher[_]).toList.asJava
+  override def getArgumentsAsMatchers: util.List[ArgumentMatcher[?]] =
+    arguments.map(EqTo(_)(serialisableEquality[AnyRef], ValueClassExtractor.instance[AnyRef], $pt): ArgumentMatcher[?]).toList.asJava
 }

--- a/common/src/main/scala/org/mockito/matchers/AllOf.scala
+++ b/common/src/main/scala/org/mockito/matchers/AllOf.scala
@@ -5,14 +5,18 @@ package matchers
  * Combine multiple matchers using AND
  */
 case class AllOf[A] private (matchers: List[ArgumentMatcher[A]]) extends ArgumentMatcher[A] {
-  override def matches(a: A) = matchers.forall(_.matches(a))
+  override def matches(a: A): Boolean = matchers.forall(_.matches(a))
 
-  override def toString =
+  override def toString: String =
     matchers match {
       case Nil            => "<any>"
       case matcher :: Nil => matcher.toString
       case _              => matchers.mkString("allOf(", ", ", ")")
     }
+
+  // Address "-Xsource:3" warning
+  @deprecated("for bincompat only, do not use", "2.0.1")
+  private[mockito] def copy(matchers: List[ArgumentMatcher[A]] = this.matchers): AllOf[A] = new AllOf(matchers)
 }
 
 object AllOf {
@@ -21,4 +25,8 @@ object AllOf {
       case AllOf(ms) => ms
       case m         => List(m)
     }.toList)
+
+  // Address "-Xsource:3" warning
+  @deprecated("for bincompat only, do not use", "2.0.1")
+  private[mockito] def apply[A](matchers: List[ArgumentMatcher[A]]): ArgumentMatcher[A] = apply(matchers *)
 }

--- a/common/src/main/scala/org/mockito/matchers/AllOf.scala
+++ b/common/src/main/scala/org/mockito/matchers/AllOf.scala
@@ -28,5 +28,5 @@ object AllOf {
 
   // Address "-Xsource:3" warning
   @deprecated("for bincompat only, do not use", "2.0.1")
-  private[mockito] def apply[A](matchers: List[ArgumentMatcher[A]]): ArgumentMatcher[A] = apply(matchers *)
+  private[mockito] def apply[A](matchers: List[ArgumentMatcher[A]]): ArgumentMatcher[A] = apply(matchers*)
 }

--- a/common/src/main/scala/org/mockito/matchers/AnyMatchers.scala
+++ b/common/src/main/scala/org/mockito/matchers/AnyMatchers.scala
@@ -1,6 +1,6 @@
 package org.mockito.matchers
 
-import org.mockito.{ ArgumentMatchers => JavaMatchers }
+import org.mockito.ArgumentMatchers as JavaMatchers
 
 private[mockito] trait AnyMatchers {
 

--- a/common/src/main/scala/org/mockito/matchers/EqMatchers.scala
+++ b/common/src/main/scala/org/mockito/matchers/EqMatchers.scala
@@ -2,7 +2,7 @@ package org.mockito
 package matchers
 
 import org.mockito.internal.ValueClassExtractor
-import org.mockito.{ ArgumentMatchers => JavaMatchers }
+import org.mockito.ArgumentMatchers as JavaMatchers
 import org.scalactic.{ Equality, Prettifier }
 
 import scala.reflect.ClassTag
@@ -22,7 +22,7 @@ private[mockito] trait EqMatchers {
   /**
    * Delegates to <code>ArgumentMatchers.refEq()</code>, it's only here so we expose all the `ArgumentMatchers` on a single place
    */
-  def refEq[T](value: T, excludeFields: String*): T = JavaMatchers.refEq(value, excludeFields: _*)
+  def refEq[T](value: T, excludeFields: String*): T = JavaMatchers.refEq(value, excludeFields*)
 
   /**
    * Creates a matcher that delegates on {{org.scalactic.Equality}} so you can always customise how the values are compared Also works with value classes

--- a/common/src/main/scala/org/mockito/matchers/EqTo.scala
+++ b/common/src/main/scala/org/mockito/matchers/EqTo.scala
@@ -2,7 +2,7 @@ package org.mockito.matchers
 
 import org.mockito.ArgumentMatcher
 import org.mockito.internal.ValueClassExtractor
-import org.scalactic.TripleEquals._
+import org.scalactic.TripleEquals.*
 import org.scalactic.{ Equality, Prettifier }
 
 case class EqTo[T: Equality: ValueClassExtractor](value: T)(implicit $pt: Prettifier) extends ArgumentMatcher[T] {

--- a/common/src/main/scala/org/mockito/matchers/NullMatchers.scala
+++ b/common/src/main/scala/org/mockito/matchers/NullMatchers.scala
@@ -1,6 +1,6 @@
 package org.mockito.matchers
 
-import org.mockito.{ ArgumentMatchers => JavaMatchers }
+import org.mockito.ArgumentMatchers as JavaMatchers
 
 private[mockito] trait NullMatchers {
 

--- a/common/src/main/scala/org/mockito/matchers/ProductOf.scala
+++ b/common/src/main/scala/org/mockito/matchers/ProductOf.scala
@@ -5,8 +5,13 @@ package matchers
  * The product (2-tuple) of two matchers
  */
 case class ProductOf[A, B] private (ma: ArgumentMatcher[A], mb: ArgumentMatcher[B]) extends ArgumentMatcher[(A, B)] {
-  override def matches(ab: (A, B)) = ab match { case (a, b) => ma.matches(a) && mb.matches(b) }
-  override def toString            = s"productOf($ma, $mb)"
+  override def matches(ab: (A, B)): Boolean = ab match { case (a, b) => ma.matches(a) && mb.matches(b) }
+  override def toString: String             = s"productOf($ma, $mb)"
+
+  // Address "-Xsource:3" warning
+  @deprecated("for bincompat only, do not use", "2.0.1")
+  private[mockito] def copy(ma: ArgumentMatcher[A] = this.ma, mb: ArgumentMatcher[B] = this.mb): ProductOf[A, B] =
+    new ProductOf(ma, mb)
 }
 
 object ProductOf {

--- a/common/src/main/scala/org/mockito/matchers/ThatMatchers.scala
+++ b/common/src/main/scala/org/mockito/matchers/ThatMatchers.scala
@@ -1,6 +1,6 @@
 package org.mockito.matchers
 
-import org.mockito.{ ArgumentMatcher, ArgumentMatchers => JavaMatchers }
+import org.mockito.{ ArgumentMatcher, ArgumentMatchers as JavaMatchers }
 
 import scala.util.Try
 

--- a/common/src/main/scala/org/mockito/matchers/Transformed.scala
+++ b/common/src/main/scala/org/mockito/matchers/Transformed.scala
@@ -7,8 +7,13 @@ package matchers
  * Technically this is 'contramapped' but that seemed like an unnecessarily jargony name.
  */
 case class Transformed[A, B] private (ma: ArgumentMatcher[A])(f: B => A) extends ArgumentMatcher[B] {
-  override def matches(b: B) = ma.matches(f(b))
-  override def toString      = s"transformed($ma: $f)"
+  override def matches(b: B): Boolean = ma.matches(f(b))
+  override def toString: String       = s"transformed($ma: $f)"
+
+  // Address "-Xsource:3" warning
+  @deprecated("for bincompat only, do not use", "2.0.1")
+  private[mockito] def copy(ma: ArgumentMatcher[A] = this.ma)(f: B => A = this.f): Transformed[A, B] =
+    new Transformed(ma)(f)
 }
 
 object Transformed {

--- a/common/src/main/scala/org/mockito/mockito.scala
+++ b/common/src/main/scala/org/mockito/mockito.scala
@@ -6,7 +6,7 @@ import org.mockito.internal.{ ValueClassExtractor, ValueClassWrapper }
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.ScalaAnswer
 import org.scalactic.Equality
-import org.scalactic.TripleEquals._
+import org.scalactic.TripleEquals.*
 
 import scala.reflect.ClassTag
 
@@ -29,9 +29,9 @@ package object mockito {
     def argsAsTuple: Any                         = args.map(_.asInstanceOf[Object]) match {
       case Nil      => Nil
       case h :: Nil => h
-      case l        => Class.forName(s"scala.Tuple${l.size}").getDeclaredConstructors.head.newInstance(l: _*)
+      case l        => Class.forName(s"scala.Tuple${l.size}").getDeclaredConstructors.head.newInstance(l*)
     }
-    def returnType: Class[_]       = ReflectionUtils.returnType(invocation)
+    def returnType: Class[?]       = ReflectionUtils.returnType(invocation)
     def returnsValueClass: Boolean = ReflectionUtils.returnsValueClass(invocation)
   }
 

--- a/common/src/main/scala/org/mockito/stubbing/DefaultAnswer.scala
+++ b/common/src/main/scala/org/mockito/stubbing/DefaultAnswer.scala
@@ -2,7 +2,7 @@ package org.mockito.stubbing
 
 import org.mockito.exceptions.base.MockitoException
 import org.mockito.invocation.InvocationOnMock
-import org.mockito.Answers._
+import org.mockito.Answers.*
 import org.mockito.internal.stubbing.defaultanswers.ReturnsMoreEmptyValues
 
 import scala.concurrent.Future
@@ -20,7 +20,7 @@ trait DefaultAnswer extends Answer[Any] with Function[InvocationOnMock, Option[A
 object DefaultAnswer {
   implicit val defaultAnswer: DefaultAnswer = ReturnsSmartNulls
 
-  def apply(from: Answer[_]): DefaultAnswer = new DecoratedAnswer(from)
+  def apply(from: Answer[?]): DefaultAnswer = new DecoratedAnswer(from)
 
   def apply(a: InvocationOnMock => Any): DefaultAnswer =
     DefaultAnswer(new Answer[Any] {
@@ -33,7 +33,7 @@ object DefaultAnswer {
     }
 }
 
-class DecoratedAnswer(from: Answer[_]) extends DefaultAnswer {
+class DecoratedAnswer(from: Answer[?]) extends DefaultAnswer {
   override def apply(invocation: InvocationOnMock): Option[Any] = Option(from.answer(invocation))
 }
 

--- a/common/src/main/scala/org/mockito/stubbing/ScalaFirstStubbing.scala
+++ b/common/src/main/scala/org/mockito/stubbing/ScalaFirstStubbing.scala
@@ -11,7 +11,7 @@ import scala.reflect.ClassTag
 
 object ScalaFirstStubbing {
   implicit def toScalaFirstStubbing[T: ValueClassExtractor](v: OngoingStubbing[T]): ScalaFirstStubbing[T] = ScalaFirstStubbing(v)
-  implicit def toMock[T](s: ScalaFirstStubbing[_]): T                                                     = s.getMock[T]
+  implicit def toMock[T](s: ScalaFirstStubbing[?]): T                                                     = s.getMock[T]
 }
 
 case class ScalaFirstStubbing[T: ValueClassExtractor](delegate: OngoingStubbing[T]) extends ScalaBaseStubbing[T] {

--- a/common/src/main/scala/org/mockito/stubbing/ScalaOngoingStubbing.scala
+++ b/common/src/main/scala/org/mockito/stubbing/ScalaOngoingStubbing.scala
@@ -7,7 +7,7 @@ import scala.reflect.ClassTag
 
 object ScalaOngoingStubbing {
   implicit def toScalaOngoingStubbing[T: ValueClassExtractor](v: OngoingStubbing[T]): ScalaOngoingStubbing[T] = ScalaOngoingStubbing(v)
-  implicit def toMock[T](s: ScalaOngoingStubbing[_]): T                                                       = s.getMock[T]
+  implicit def toMock[T](s: ScalaOngoingStubbing[?]): T                                                       = s.getMock[T]
 }
 
 case class ScalaOngoingStubbing[T: ValueClassExtractor](delegate: OngoingStubbing[T]) extends ScalaBaseStubbing[T] {

--- a/common/src/test/scala/org/mockito/matchers/MatcherProps.scala
+++ b/common/src/test/scala/org/mockito/matchers/MatcherProps.scala
@@ -2,20 +2,20 @@ package org.mockito
 package matchers
 
 import cats.laws.discipline.MiniInt
-import cats.laws.discipline.arbitrary._
-import org.mockito.internal.matchers._
-import org.scalacheck._
+import cats.laws.discipline.arbitrary.*
+import org.mockito.internal.matchers.*
+import org.scalacheck.*
 
 import Arbitrary.arbitrary
-import Gen._
-import Prop._
+import Gen.*
+import Prop.*
 
 class MatcherProps extends Properties("matchers") {
-  import Generators._
+  import Generators.*
 
   property("AllOf") = forAll(chooseNum(0, 8))(length =>
     forAll(listOfN(length, arbitrary[ArgumentMatcher[MiniInt]]), arbitrary[MiniInt]) { case (matchers, value) =>
-      val allOf     = AllOf(matchers: _*)
+      val allOf     = AllOf(matchers*)
       val stringRep = allOf.toString
 
       classify(allOf.matches(value), "matches", "doesn't match") {

--- a/core/src/main/scala/org/mockito/ArgumentMatchersSugar.scala
+++ b/core/src/main/scala/org/mockito/ArgumentMatchersSugar.scala
@@ -11,7 +11,7 @@
 
 package org.mockito
 
-import org.mockito.matchers._
+import org.mockito.matchers.*
 
 /**
  * Trait that provides some syntax sugar and type mapping.

--- a/core/src/main/scala/org/mockito/IdiomaticMockitoBase.scala
+++ b/core/src/main/scala/org/mockito/IdiomaticMockitoBase.scala
@@ -84,11 +84,11 @@ object IdiomaticMockitoBase {
   }
 
   class ReturnActions[T](os: ScalaFirstStubbing[T]) {
-    def apply(value: T, values: T*): ScalaOngoingStubbing[T] = os.thenReturn(value, values: _*)
+    def apply(value: T, values: T*): ScalaOngoingStubbing[T] = os.thenReturn(value, values*)
   }
 
   class ThrowActions[T](os: ScalaFirstStubbing[T]) {
-    def apply[E <: Throwable](e: E*): ScalaOngoingStubbing[T] = os thenThrow (e: _*)
+    def apply[E <: Throwable](e: E*): ScalaOngoingStubbing[T] = os thenThrow (e*)
   }
 
   // types for postfix verifications

--- a/core/src/main/scala/org/mockito/IdiomaticStubbing.scala
+++ b/core/src/main/scala/org/mockito/IdiomaticStubbing.scala
@@ -1,10 +1,10 @@
 package org.mockito
 
-import org.mockito.WhenMacro._
+import org.mockito.WhenMacro.*
 import org.mockito.stubbing.ScalaOngoingStubbing
 
 trait IdiomaticStubbing extends MockitoEnhancer with ScalacticSerialisableHack {
-  import org.mockito.IdiomaticMockitoBase._
+  import org.mockito.IdiomaticMockitoBase.*
 
   implicit class StubbingOps[T](stubbing: T) {
     def shouldReturn: ReturnActions[T] = macro WhenMacro.shouldReturn[T]

--- a/core/src/main/scala/org/mockito/MockitoScalaSession.scala
+++ b/core/src/main/scala/org/mockito/MockitoScalaSession.scala
@@ -6,12 +6,12 @@ import org.mockito.internal.stubbing.StubbedInvocationMatcher
 import org.mockito.invocation.{ DescribedInvocation, Invocation, Location }
 import org.mockito.listeners.MockCreationListener
 import org.mockito.mock.MockCreationSettings
-import org.mockito.quality.{ Strictness => JavaStrictness }
+import org.mockito.quality.Strictness as JavaStrictness
 import org.mockito.session.MockitoSessionLogger
 import org.scalactic.Equality
-import org.scalactic.TripleEquals._
+import org.scalactic.TripleEquals.*
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.collection.mutable
 
 class MockitoScalaSession(name: String, strictness: Strictness, logger: MockitoSessionLogger) {
@@ -155,7 +155,7 @@ object MockitoScalaSession {
 
     private val mocks = mutable.Set.empty[AnyRef]
 
-    override def onMockCreated(mock: AnyRef, settings: MockCreationSettings[_]): Unit =
+    override def onMockCreated(mock: AnyRef, settings: MockCreationSettings[?]): Unit =
       if ((settings.getStrictness !== JavaStrictness.LENIENT) && (strictness !== Strictness.Lenient)) mocks += mock
   }
 }

--- a/core/src/main/scala/org/mockito/PostfixVerifications.scala
+++ b/core/src/main/scala/org/mockito/PostfixVerifications.scala
@@ -10,7 +10,7 @@ trait IdiomaticVerifications {
 
 trait PostfixVerifications extends IdiomaticVerifications {
 
-  import org.mockito.IdiomaticMockitoBase._
+  import org.mockito.IdiomaticMockitoBase.*
 
   implicit class VerifyingOps[T](stubbing: T) {
     def was(called: Called.type)(implicit order: VerifyOrder): Verification = macro VerifyMacro.wasMacro[T, Verification]

--- a/core/src/main/scala/org/mockito/PrefixExpectations.scala
+++ b/core/src/main/scala/org/mockito/PrefixExpectations.scala
@@ -2,7 +2,7 @@ package org.mockito
 
 trait PrefixExpectations extends IdiomaticVerifications {
 
-  import org.mockito.IdiomaticMockitoBase._
+  import org.mockito.IdiomaticMockitoBase.*
 
   type Calls = Times
 

--- a/core/src/main/scala/org/mockito/matchers/MacroBasedMatchers.scala
+++ b/core/src/main/scala/org/mockito/matchers/MacroBasedMatchers.scala
@@ -1,6 +1,6 @@
 package org.mockito.matchers
 
-import org.mockito.{ ArgumentMatchers => JavaMatchers }
+import org.mockito.ArgumentMatchers as JavaMatchers
 
 trait MacroBasedMatchers {
 

--- a/macro-common/src/main/scala/org/mockito/internal/MacroDebug.scala
+++ b/macro-common/src/main/scala/org/mockito/internal/MacroDebug.scala
@@ -4,7 +4,7 @@ import scala.reflect.macros.blackbox
 
 object MacroDebug {
   def debugResult(c: blackbox.Context)(enablingFlag: String)(tree: c.Tree): Unit = {
-    import c.universe._
+    import c.universe.*
 
     if (c.settings.contains(enablingFlag)) {
       val pos = s"${c.enclosingPosition.source.file.name}:${c.enclosingPosition.line}"

--- a/macro-common/src/main/scala/org/mockito/internal/ValueClassExtractor.scala
+++ b/macro-common/src/main/scala/org/mockito/internal/ValueClassExtractor.scala
@@ -33,7 +33,7 @@ object ValueClassExtractor {
   implicit def instance[VC]: ValueClassExtractor[VC] = macro materialise[VC]
 
   def materialise[VC: c.WeakTypeTag](c: blackbox.Context): c.Expr[ValueClassExtractor[VC]] = {
-    import c.universe._
+    import c.universe.*
     val tpe          = weakTypeOf[VC]
     val typeSymbol   = tpe.typeSymbol
     val isValueClass = typeSymbol.isClass && typeSymbol.asClass.isDerivedValueClass

--- a/macro-common/src/main/scala/org/mockito/internal/ValueClassWrapper.scala
+++ b/macro-common/src/main/scala/org/mockito/internal/ValueClassWrapper.scala
@@ -33,7 +33,7 @@ object ValueClassWrapper {
   implicit def instance[VC]: ValueClassWrapper[VC] = macro materialise[VC]
 
   def materialise[VC: c.WeakTypeTag](c: blackbox.Context): c.Expr[ValueClassWrapper[VC]] = {
-    import c.universe._
+    import c.universe.*
     val tpe          = weakTypeOf[VC]
     val typeSymbol   = tpe.typeSymbol
     val isValueClass = typeSymbol.isClass && typeSymbol.asClass.isDerivedValueClass

--- a/macro/src/main/scala/org/mockito/DoSomethingMacro.scala
+++ b/macro/src/main/scala/org/mockito/DoSomethingMacro.scala
@@ -1,13 +1,13 @@
 package org.mockito
 
-import org.mockito.Utils._
+import org.mockito.Utils.*
 import org.mockito.internal.MacroDebug.debugResult
 
 import scala.reflect.macros.blackbox
 
 object DoSomethingMacro {
   def doesNothing(c: blackbox.Context)(): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     val r = c.macroApplication match {
       case q"$_.StubbingOps[$_]($invocation).shouldDoNothing()" =>
@@ -24,7 +24,7 @@ object DoSomethingMacro {
   }
 
   def returnedBy[T: c.WeakTypeTag, S](c: blackbox.Context)(stubbing: c.Expr[T])($ev: c.Expr[S]): c.Expr[S] = {
-    import c.universe._
+    import c.universe.*
 
     val r = c.Expr[S] {
       c.macroApplication match {
@@ -39,7 +39,7 @@ object DoSomethingMacro {
   }
 
   def returnedF[T: c.WeakTypeTag, S](c: blackbox.Context)(stubbing: c.Expr[T])(F: c.Tree, $ev: c.Expr[S]): c.Expr[S] = {
-    import c.universe._
+    import c.universe.*
 
     val r = c.Expr[S] {
       c.macroApplication match {
@@ -54,7 +54,7 @@ object DoSomethingMacro {
   }
 
   def returnedFG[T: c.WeakTypeTag, S](c: blackbox.Context)(stubbing: c.Expr[T])(F: c.Tree, G: c.Tree, $ev: c.Expr[S]): c.Expr[S] = {
-    import c.universe._
+    import c.universe.*
 
     val r = c.Expr[S] {
       c.macroApplication match {
@@ -69,7 +69,7 @@ object DoSomethingMacro {
   }
 
   def answeredBy[T: c.WeakTypeTag, S](c: blackbox.Context)(stubbing: c.Expr[T])($ev: c.Expr[S]): c.Expr[S] = {
-    import c.universe._
+    import c.universe.*
 
     val r = c.Expr[S] {
       c.macroApplication match {
@@ -84,7 +84,7 @@ object DoSomethingMacro {
   }
 
   def answeredF[T: c.WeakTypeTag, S](c: blackbox.Context)(stubbing: c.Expr[T])(F: c.Tree, $ev: c.Expr[S]): c.Expr[S] = {
-    import c.universe._
+    import c.universe.*
 
     val r = c.Expr[S] {
       c.macroApplication match {
@@ -99,7 +99,7 @@ object DoSomethingMacro {
   }
 
   def answeredFG[T: c.WeakTypeTag, S](c: blackbox.Context)(stubbing: c.Expr[T])(F: c.Tree, G: c.Tree, $ev: c.Expr[S]): c.Expr[S] = {
-    import c.universe._
+    import c.universe.*
 
     val r = c.Expr[S] {
       c.macroApplication match {
@@ -114,7 +114,7 @@ object DoSomethingMacro {
   }
 
   def thrownBy[T: c.WeakTypeTag](c: blackbox.Context)(stubbing: c.Expr[T])($ev: c.Tree): c.Expr[T] = {
-    import c.universe._
+    import c.universe.*
 
     val r = c.Expr[T] {
       c.macroApplication match {
@@ -129,7 +129,7 @@ object DoSomethingMacro {
   }
 
   def raised[T: c.WeakTypeTag](c: blackbox.Context)(stubbing: c.Expr[T])(F: c.Tree): c.Expr[T] = {
-    import c.universe._
+    import c.universe.*
 
     val r = c.Expr[T] {
       c.macroApplication match {
@@ -144,7 +144,7 @@ object DoSomethingMacro {
   }
 
   def raisedG[T: c.WeakTypeTag](c: blackbox.Context)(stubbing: c.Expr[T])(F: c.Tree, G: c.Tree): c.Expr[T] = {
-    import c.universe._
+    import c.universe.*
 
     val r = c.Expr[T] {
       c.macroApplication match {
@@ -159,7 +159,7 @@ object DoSomethingMacro {
   }
 
   def calledBy[T: c.WeakTypeTag](c: blackbox.Context)(stubbing: c.Expr[T]): c.Expr[T] = {
-    import c.universe._
+    import c.universe.*
 
     val r = c.Expr[T] {
       c.macroApplication match {
@@ -174,7 +174,7 @@ object DoSomethingMacro {
   }
 
   private def transformInvocation(c: blackbox.Context)(invocation: c.Tree, action: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     val pf: PartialFunction[c.Tree, c.Tree] = {
       case q"$obj.$method[..$targs](...$args)" =>

--- a/macro/src/main/scala/org/mockito/ExpectMacro.scala
+++ b/macro/src/main/scala/org/mockito/ExpectMacro.scala
@@ -13,7 +13,7 @@ object ExpectMacro extends VerificationMacroTransformer {
   }
 
   private def transformExpectation[R](c: blackbox.Context)(called: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     called match {
       case q"$_.this.expect.no($_).to($obj.$methodOrField)($order)" =>
@@ -51,7 +51,7 @@ object ExpectMacro extends VerificationMacroTransformer {
   }
 
   def transformNoInteractionsExpectation[R](c: blackbox.Context)(called: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     called match {
       case q"$_.this.expect.no($_.calls).on($obj)" =>

--- a/macro/src/main/scala/org/mockito/Specs2VerifyMacro.scala
+++ b/macro/src/main/scala/org/mockito/Specs2VerifyMacro.scala
@@ -1,6 +1,6 @@
 package org.mockito
 
-import org.mockito.Utils._
+import org.mockito.Utils.*
 import org.mockito.internal.MacroDebug.debugResult
 
 import scala.reflect.macros.blackbox
@@ -16,7 +16,7 @@ object Specs2VerifyMacro extends VerificationMacroTransformer {
   private val WasWere = "(was|were)".r.pattern
 
   def wasMacro[T: c.WeakTypeTag, R](c: blackbox.Context)(calls: c.Expr[T])(order: c.Expr[VerifyOrder]): c.Expr[R] = {
-    import c.universe._
+    import c.universe.*
 
     val transformSpecs2Verification: PartialFunction[c.Tree, c.Tree] = {
       case q"$_.$numWord[$_]($obj).$method[..$targs](...$args)" =>

--- a/macro/src/main/scala/org/mockito/Utils.scala
+++ b/macro/src/main/scala/org/mockito/Utils.scala
@@ -58,7 +58,7 @@ object Utils {
   private def isSpecs2Matcher(methodName: String): Boolean = specs2implicits.pattern.matcher(methodName).matches
 
   private[mockito] def isMatcher(c: blackbox.Context)(arg: c.Tree): Boolean = {
-    import c.universe._
+    import c.universe.*
     if (arg.toString().contains("org.mockito.matchers.MacroMatchers")) true
     else {
       val methodName = arg match {
@@ -79,7 +79,7 @@ object Utils {
     args.map(arg => transformArg(c)(arg))
 
   private[mockito] def transformArg(c: blackbox.Context)(arg: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
     if (isMatcher(c)(arg)) arg
     else
       arg match {
@@ -90,12 +90,12 @@ object Utils {
   }
 
   private[mockito] def packageName(c: blackbox.Context)(cls: c.TermName): c.TermName = {
-    import c.universe._
+    import c.universe.*
     if (cls.toString.contains("Scalaz")) TermName("scalaz") else TermName("cats")
   }
 
   private[mockito] def className(c: blackbox.Context)(cls: c.TermName, start: String): c.TermName = {
-    import c.universe._
+    import c.universe.*
     if (cls.toString.contains("Scalaz")) TermName(start + "Scalaz") else TermName(start + "Cats")
   }
 }

--- a/macro/src/main/scala/org/mockito/VerifyMacro.scala
+++ b/macro/src/main/scala/org/mockito/VerifyMacro.scala
@@ -1,6 +1,6 @@
 package org.mockito
 
-import org.mockito.Utils._
+import org.mockito.Utils.*
 import org.mockito.internal.MacroDebug.debugResult
 import org.mockito.internal.verification.VerificationModeFactory
 import org.mockito.verification.VerificationMode
@@ -40,7 +40,7 @@ object VerifyMacro extends VerificationMacroTransformer {
 
 private[mockito] trait VerificationMacroTransformer {
   protected def transformInvocation(c: blackbox.Context)(invocation: c.Tree, order: c.Tree, times: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     try doTransformInvocation(c)(invocation, order, times)
     catch {
@@ -49,7 +49,7 @@ private[mockito] trait VerificationMacroTransformer {
   }
 
   protected def doTransformInvocation(c: blackbox.Context)(invocation: c.Tree, order: c.Tree, times: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     val pf: PartialFunction[c.Tree, c.Tree] = {
       case q"$obj.$method[..$targs](...$args)" =>
@@ -88,7 +88,7 @@ private[mockito] trait VerificationMacroTransformer {
   }
 
   protected def transformVerification[T: c.WeakTypeTag, R](c: blackbox.Context)(called: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     def transformMockWasNeverCalled(obj: c.Tree, called: c.Tree): c.Tree =
       called match {
@@ -151,7 +151,7 @@ object VerifyUnOrdered extends VerifyOrder {
 }
 
 case class VerifyInOrder(mocks: Seq[AnyRef]) extends VerifyOrder {
-  private val _inOrder = Mockito.inOrder(mocks: _*)
+  private val _inOrder = Mockito.inOrder(mocks*)
 
   override def verify[T](mock: T): T                                      = _inOrder.verify(mock)
   override def verifyWithMode[T](mock: T, mode: ScalaVerificationMode): T = _inOrder.verify(mock, mode.verificationMode)

--- a/macro/src/main/scala/org/mockito/WhenMacro.scala
+++ b/macro/src/main/scala/org/mockito/WhenMacro.scala
@@ -1,6 +1,6 @@
 package org.mockito
 
-import org.mockito.Utils._
+import org.mockito.Utils.*
 import org.mockito.internal.MacroDebug.debugResult
 import org.mockito.internal.ValueClassWrapper
 import org.mockito.stubbing.{ ScalaFirstStubbing, ScalaOngoingStubbing }
@@ -10,7 +10,7 @@ import scala.reflect.macros.blackbox
 
 object WhenMacro {
   private def transformInvocation(c: blackbox.Context)(invocation: c.Tree): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     val pf: PartialFunction[c.Tree, c.Tree] = {
       case q"$obj.$method[..$targs](...$args)" =>
@@ -51,7 +51,7 @@ object WhenMacro {
   private val FunctionalShouldReturnOptions                       = ShouldReturnOptions.map(_ + "F")
   private val FunctionalShouldReturnOptions2                      = ShouldReturnOptions.map(_ + "FG")
   def shouldReturn[T: c.WeakTypeTag](c: blackbox.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     val r = c.macroApplication match {
       case q"$_.StubbingOps[$t]($invocation).$m" if ShouldReturnOptions.contains(m.toString) =>
@@ -70,7 +70,7 @@ object WhenMacro {
   }
 
   def isLenient[T: c.WeakTypeTag](c: blackbox.Context)(): c.Expr[Unit] = {
-    import c.universe._
+    import c.universe.*
 
     val r = c.Expr[Unit] {
       c.macroApplication match {
@@ -90,7 +90,7 @@ object WhenMacro {
 
   val ShouldCallOptions                                                                                                          = Set("shouldCall", "mustCall", "calls")
   def shouldCallRealMethod[T: c.WeakTypeTag](c: blackbox.Context)(crm: c.Expr[RealMethod.type]): c.Expr[ScalaOngoingStubbing[T]] = {
-    import c.universe._
+    import c.universe.*
 
     val r = c.Expr[ScalaOngoingStubbing[T]] {
       c.macroApplication match {
@@ -108,7 +108,7 @@ object WhenMacro {
   private val FunctionalShouldFailOptions                        = Set("shouldFailWith", "mustFailWith", "failsWith", "raises")
   private val FunctionalShouldFailOptions2                       = Set("shouldFailWithG", "mustFailWithG", "failsWithG", "raisesG")
   def shouldThrow[T: c.WeakTypeTag](c: blackbox.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     val r = c.macroApplication match {
       case q"$_.StubbingOps[$t]($invocation).$m" if ShouldThrowOptions.contains(m.toString) =>
@@ -454,7 +454,7 @@ object WhenMacro {
   private val FunctionalShouldAnswerOptions                       = ShouldAnswerOptions.map(_ + "F")
   private val FunctionalShouldAnswerOptions2                      = ShouldAnswerOptions.map(_ + "FG")
   def shouldAnswer[T: c.WeakTypeTag](c: blackbox.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     val r = c.macroApplication match {
       case q"$_.StubbingOps[$t]($invocation).$m" if ShouldAnswerOptions.contains(m.toString) =>
@@ -478,7 +478,7 @@ object WhenMacro {
 
   private val ShouldAnswerPFOptions                                 = Set("shouldAnswerPF", "mustAnswerPF", "answersPF")
   def shouldAnswerPF[T: c.WeakTypeTag](c: blackbox.Context): c.Tree = {
-    import c.universe._
+    import c.universe.*
 
     val r = c.macroApplication match {
       case q"$_.StubbingOps[$t]($invocation).$m" if ShouldAnswerPFOptions.contains(m.toString) =>

--- a/macro/src/main/scala/org/mockito/captor/Captor.scala
+++ b/macro/src/main/scala/org/mockito/captor/Captor.scala
@@ -7,9 +7,9 @@ import org.mockito.internal.ScalaVersion
 import org.mockito.internal.ScalaVersion.{ V2_12, V2_13 }
 import org.mockito.{ clazz, ArgumentCaptor }
 import org.scalactic.Equality
-import org.scalactic.TripleEquals._
+import org.scalactic.TripleEquals.*
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.reflect.ClassTag
 import scala.reflect.macros.blackbox
 import scala.util.{ Failure, Try }
@@ -61,7 +61,7 @@ object Captor {
   implicit def materializeValueClassCaptor[T]: Captor[T] = macro materializeValueClassCaptorMacro[T]
 
   def materializeValueClassCaptorMacro[T: c.WeakTypeTag](c: blackbox.Context): c.Expr[Captor[T]] = {
-    import c.universe._
+    import c.universe.*
     val tpe          = weakTypeOf[T]
     val typeSymbol   = tpe.typeSymbol
     val isValueClass = typeSymbol.isClass && typeSymbol.asClass.isDerivedValueClass

--- a/macro/src/main/scala/org/mockito/matchers/DefaultValueProvider.scala
+++ b/macro/src/main/scala/org/mockito/matchers/DefaultValueProvider.scala
@@ -17,7 +17,7 @@ object DefaultValueProvider {
   implicit def default[T]: DefaultValueProvider[T] = macro _defaultValueProvider[T]
 
   def _defaultValueProvider[T: c.WeakTypeTag](c: blackbox.Context): c.Expr[DefaultValueProvider[T]] = {
-    import c.universe._
+    import c.universe.*
     val tpe          = weakTypeOf[T]
     val typeSymbol   = tpe.typeSymbol
     val isValueClass = typeSymbol.isClass && typeSymbol.asClass.isDerivedValueClass

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,5 +1,5 @@
-import sbt._
-import sbt.Keys._
+import sbt.*
+import sbt.Keys.*
 
 object Dependencies {
 

--- a/scalatest/src/main/scala/org/mockito/scalatest/MockitoSessionFixture.scala
+++ b/scalatest/src/main/scala/org/mockito/scalatest/MockitoSessionFixture.scala
@@ -1,7 +1,7 @@
 package org.mockito.scalatest
 
 import org.mockito.{ MockitoScalaSession, Strictness }
-import org.scalatest._
+import org.scalatest.*
 
 private[mockito] trait MockitoSessionFixture extends TestSuite { this: Suite =>
 

--- a/scalatest/src/main/scala/org/mockito/scalatest/ResetMocksAfterEachTestBase.scala
+++ b/scalatest/src/main/scala/org/mockito/scalatest/ResetMocksAfterEachTestBase.scala
@@ -6,7 +6,7 @@ import org.mockito.stubbing.DefaultAnswer
 import org.mockito.{ MockCreator, MockSettings }
 import org.scalactic.Prettifier
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.WeakTypeTag
 

--- a/scalatest/src/test/scala-2.12/user/org/mockito/stubbing/ReturnsEmptyValuesTest.scala
+++ b/scalatest/src/test/scala-2.12/user/org/mockito/stubbing/ReturnsEmptyValuesTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.{ OptionValues, TryValues }
-import user.org.mockito.stubbing.DefaultAnswerTest._
+import user.org.mockito.stubbing.DefaultAnswerTest.*
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer

--- a/scalatest/src/test/scala-2.13/user/org/mockito/stubbing/ReturnsEmptyValuesTest.scala
+++ b/scalatest/src/test/scala-2.13/user/org/mockito/stubbing/ReturnsEmptyValuesTest.scala
@@ -4,7 +4,7 @@ import org.mockito.exceptions.base.MockitoException
 import org.mockito.{ DefaultAnswers, IdiomaticMockito }
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ OptionValues, TryValues }
-import user.org.mockito.stubbing.DefaultAnswerTest._
+import user.org.mockito.stubbing.DefaultAnswerTest.*
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer

--- a/scalatest/src/test/scala/user/org/mockito/DoSomethingTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/DoSomethingTest.scala
@@ -3,7 +3,7 @@ package user.org.mockito
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.mockito.invocation.InvocationOnMock
-import org.mockito._
+import org.mockito.*
 import user.org.mockito.matchers.{ ValueCaseClassInt, ValueCaseClassString, ValueClass }
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/scalatest/src/test/scala/user/org/mockito/IdiomaticStubbingTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/IdiomaticStubbingTest.scala
@@ -3,7 +3,7 @@ package user.org.mockito
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.mockito.invocation.InvocationOnMock
-import org.mockito._
+import org.mockito.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import user.org.mockito.matchers.{ ValueCaseClassInt, ValueCaseClassString, ValueClass }

--- a/scalatest/src/test/scala/user/org/mockito/Issue256.scala
+++ b/scalatest/src/test/scala/user/org/mockito/Issue256.scala
@@ -3,8 +3,8 @@ package user.org.mockito
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.mockito.{ ArgumentMatchersSugar, IdiomaticMockito, MockitoScalaSession }
-import IdiomaticMockito._
-import ArgumentMatchersSugar._
+import IdiomaticMockito.*
+import ArgumentMatchersSugar.*
 
 class Issue256 extends AnyWordSpec with Matchers {
 

--- a/scalatest/src/test/scala/user/org/mockito/MalformedClassError.scala
+++ b/scalatest/src/test/scala/user/org/mockito/MalformedClassError.scala
@@ -1,6 +1,6 @@
 package user.org.mockito
 
-import user.org.mockito.MalformedClassError._
+import user.org.mockito.MalformedClassError.*
 import org.mockito.IdiomaticMockito
 import org.scalatest.concurrent.ScalaFutures
 

--- a/scalatest/src/test/scala/user/org/mockito/MockitoScalaSessionTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/MockitoScalaSessionTest.scala
@@ -1,6 +1,6 @@
 package user.org.mockito
 
-import org.mockito._
+import org.mockito.*
 import org.mockito.exceptions.misusing.{ UnexpectedInvocationException, UnnecessaryStubbingException }
 import org.mockito.exceptions.verification.SmartNullPointerException
 import org.mockito.internal.creation.settings.CreationSettings
@@ -15,7 +15,7 @@ class MockitoScalaSessionTest extends AnyWordSpec with IdiomaticMockito with Mat
   val scenarios = Table(
     ("testDouble", "foo", "parametrisedFoo", "fooBar"),
     ("mock", () => mock[Foo], (mockSettings: MockSettings) => mock[Foo](mockSettings), ""),
-    ("spy", () => spy(new Foo), (mockSettings: MockSettings) => spy(new Foo, mockSettings.asInstanceOf[CreationSettings[_]].isLenient), "bar")
+    ("spy", () => spy(new Foo), (mockSettings: MockSettings) => spy(new Foo, mockSettings.asInstanceOf[CreationSettings[?]].isLenient), "bar")
   )
 
   class FinalEqualsAndHashcode {

--- a/scalatest/src/test/scala/user/org/mockito/MockitoSugarTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/MockitoSugarTest.scala
@@ -8,7 +8,7 @@ import org.mockito.exceptions.misusing.WrongTypeOfReturnValue
 import org.mockito.exceptions.verification.{ ArgumentsAreDifferent, WantedButNotInvoked }
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.{ CallsRealMethods, DefaultAnswer, ScalaFirstStubbing }
-import org.mockito._
+import org.mockito.*
 import org.scalactic.Prettifier
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{ EitherValues, OptionValues }
@@ -405,7 +405,7 @@ class MockitoSugarTest extends AnyWordSpec with MockitoSugar with Matchers with 
     "work when getting varargs from collections" in {
       val aMock = mock[Baz]
 
-      when(aMock.varargMethod("hola", List(1, 2, 3): _*)) thenReturn 42
+      when(aMock.varargMethod("hola", List(1, 2, 3)*)) thenReturn 42
 
       aMock.varargMethod("hola", 1, 2, 3) shouldBe 42
 
@@ -415,7 +415,7 @@ class MockitoSugarTest extends AnyWordSpec with MockitoSugar with Matchers with 
     "work when getting varargs from collections (with matchers)" in {
       val aMock = mock[Baz]
 
-      when(aMock.varargMethod(eqTo("hola"), eqTo(List(1, 2, 3)): _*)) thenReturn 42
+      when(aMock.varargMethod(eqTo("hola"), eqTo(List(1, 2, 3))*)) thenReturn 42
 
       aMock.varargMethod("hola", 1, 2, 3) shouldBe 42
 

--- a/scalatest/src/test/scala/user/org/mockito/PostfixVerificationsTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/PostfixVerificationsTest.scala
@@ -4,7 +4,7 @@ import java.io.{ File, FileOutputStream, ObjectOutputStream }
 
 import org.mockito.captor.ArgCaptor
 import org.mockito.exceptions.misusing.NotAMockException
-import org.mockito.exceptions.verification._
+import org.mockito.exceptions.verification.*
 import org.mockito.{ ArgumentMatchersSugar, IdiomaticMockito, IdiomaticStubbing, MockitoSugar }
 import org.scalactic.Prettifier
 import org.scalatest.FixtureContext
@@ -276,7 +276,7 @@ class PostfixVerificationsTest extends AnyWordSpec with IdiomaticMockitoTestSetu
 
         val s = List("horse", "red")
 
-        foo.fooWithVarArg(s: _*)
+        foo.fooWithVarArg(s*)
         foo.fooWithVarArg("horse", "red") was called
 
         foo.fooWithVarArg(*, *) wasCalled twice
@@ -304,7 +304,7 @@ class PostfixVerificationsTest extends AnyWordSpec with IdiomaticMockitoTestSetu
 
         val b = Seq(Bread("Chipa"), Bread("Tortilla"))
 
-        foo.valueClassWithVarArg(b: _*)
+        foo.valueClassWithVarArg(b*)
         foo.valueClassWithVarArg(Bread("Chipa"), Bread("Tortilla")) was called
       }
 
@@ -358,7 +358,7 @@ class PostfixVerificationsTest extends AnyWordSpec with IdiomaticMockitoTestSetu
         org.fooWithVarArgAndSecondParameterList(*)(*) wasCalled twice
 
         val s = List("horse", "red", "meh")
-        org.fooWithVarArgAndSecondParameterList(s: _*)(cheese)
+        org.fooWithVarArgAndSecondParameterList(s*)(cheese)
         org.fooWithVarArgAndSecondParameterList("horse", "red", "meh")(cheese) was called
         org.fooWithVarArgAndSecondParameterList(*)(*) wasCalled thrice
       }
@@ -399,7 +399,7 @@ class PostfixVerificationsTest extends AnyWordSpec with IdiomaticMockitoTestSetu
 
         val b = Seq(Bread("Chipa"), Bread("Tortilla"))
 
-        org.valueClassWithVarArgAndSecondParameterList(b: _*)(cheese)
+        org.valueClassWithVarArgAndSecondParameterList(b*)(cheese)
         org.valueClassWithVarArgAndSecondParameterList(Bread("Chipa"), Bread("Tortilla"))(cheese) was called
       }
 
@@ -712,12 +712,12 @@ class PostfixVerificationsTest extends AnyWordSpec with IdiomaticMockitoTestSetu
       val aMock = mock[Baz]
       val args  = List(1, 2, 3)
 
-      aMock.varargMethod("hola", args: _*) returns 42
+      aMock.varargMethod("hola", args*) returns 42
 
       aMock.varargMethod("hola", 1, 2, 3) shouldBe 42
 
-      aMock.varargMethod("hola", List(1, 2, 3): _*) was called
-      aMock.varargMethod("hola", Vector(1, 2, 3): _*) was called
+      aMock.varargMethod("hola", List(1, 2, 3)*) was called
+      aMock.varargMethod("hola", Vector(1, 2, 3)*) was called
       aMock.varargMethod("hola", 1, 2, 3) was called
     }
 

--- a/scalatest/src/test/scala/user/org/mockito/PrefixExpectationsTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/PrefixExpectationsTest.scala
@@ -4,7 +4,7 @@ import java.io.{ File, FileOutputStream, ObjectOutputStream }
 
 import org.mockito.captor.ArgCaptor
 import org.mockito.exceptions.misusing.MissingMethodInvocationException
-import org.mockito.exceptions.verification._
+import org.mockito.exceptions.verification.*
 import org.mockito.{ ArgumentMatchersSugar, IdiomaticMockito, MockitoSugar }
 import org.scalatest.FixtureContext
 import org.scalatest.matchers.should.Matchers
@@ -299,7 +299,7 @@ class PrefixExpectationsTest extends AnyWordSpec with Matchers with ArgumentMatc
 
         val s = List("horse", "red")
 
-        foo.fooWithVarArg(s: _*)
+        foo.fooWithVarArg(s*)
         expect a call to foo.fooWithVarArg("horse", "red")
 
         expect two calls to foo.fooWithVarArg(*, *)
@@ -327,7 +327,7 @@ class PrefixExpectationsTest extends AnyWordSpec with Matchers with ArgumentMatc
 
         val b = Seq(Bread("Chipa"), Bread("Tortilla"))
 
-        foo.valueClassWithVarArg(b: _*)
+        foo.valueClassWithVarArg(b*)
         expect a call to foo.valueClassWithVarArg(Bread("Chipa"), Bread("Tortilla"))
       }
 
@@ -382,7 +382,7 @@ class PrefixExpectationsTest extends AnyWordSpec with Matchers with ArgumentMatc
         expect two calls to org.fooWithVarArgAndSecondParameterList(*)(*)
 
         val s = List("horse", "red", "meh")
-        org.fooWithVarArgAndSecondParameterList(s: _*)(cheese)
+        org.fooWithVarArgAndSecondParameterList(s*)(cheese)
         expect a call to org.fooWithVarArgAndSecondParameterList("horse", "red", "meh")(cheese)
         expect three calls to org.fooWithVarArgAndSecondParameterList(*)(*)
       }
@@ -423,7 +423,7 @@ class PrefixExpectationsTest extends AnyWordSpec with Matchers with ArgumentMatc
 
         val b = Seq(Bread("Chipa"), Bread("Tortilla"))
 
-        org.valueClassWithVarArgAndSecondParameterList(b: _*)(cheese)
+        org.valueClassWithVarArgAndSecondParameterList(b*)(cheese)
         expect a call to org.valueClassWithVarArgAndSecondParameterList(Bread("Chipa"), Bread("Tortilla"))(cheese)
       }
 
@@ -738,12 +738,12 @@ class PrefixExpectationsTest extends AnyWordSpec with Matchers with ArgumentMatc
       val aMock = mock[Baz]
       val args  = List(1, 2, 3)
 
-      aMock.varargMethod("hola", args: _*) returns 42
+      aMock.varargMethod("hola", args*) returns 42
 
       aMock.varargMethod("hola", 1, 2, 3) shouldBe 42
 
-      expect a call to aMock.varargMethod("hola", List(1, 2, 3): _*)
-      expect a call to aMock.varargMethod("hola", Vector(1, 2, 3): _*)
+      expect a call to aMock.varargMethod("hola", List(1, 2, 3)*)
+      expect a call to aMock.varargMethod("hola", Vector(1, 2, 3)*)
       expect a call to aMock.varargMethod("hola", 1, 2, 3)
     }
 

--- a/scalatest/src/test/scala/user/org/mockito/captor/ArgCaptorTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/captor/ArgCaptorTest.scala
@@ -5,7 +5,7 @@ import org.mockito.exceptions.base.MockitoAssertionError
 import org.mockito.exceptions.verification.{ TooFewActualInvocations, TooManyActualInvocations }
 import org.mockito.{ IdiomaticMockito, MockitoSugar }
 import org.scalactic.{ Equality, StringNormalizations }
-import user.org.mockito.captor.ArgCaptorTest._
+import user.org.mockito.captor.ArgCaptorTest.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -45,7 +45,7 @@ class ArgCaptorTest extends AnyWordSpec with MockitoSugar with Matchers {
     "works with Equality" in {
       val aMock  = mock[Foo]
       val captor = ArgCaptor[String]
-      import StringNormalizations._
+      import StringNormalizations.*
 
       implicit val eq: Equality[String] = decided by defaultEquality[String] afterBeing lowerCased
 

--- a/scalatest/src/test/scala/user/org/mockito/matchers/EqMatchersTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/matchers/EqMatchersTest.scala
@@ -126,7 +126,7 @@ class EqMatchersTest extends AnyFlatSpec with MockitoSugar with Matchers with Ar
   }
 
   "eqTo[T]" should "work when an implicit Equality is in scope" in {
-    import StringNormalizations._
+    import StringNormalizations.*
 
     implicit val eq: Equality[String] = decided by defaultEquality[String] afterBeing lowerCased
 

--- a/scalatest/src/test/scala/user/org/mockito/scalatest/AsyncIdiomaticMockitoTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/scalatest/AsyncIdiomaticMockitoTest.scala
@@ -36,7 +36,7 @@ class AsyncIdiomaticMockitoTest extends AsyncWordSpec with Matchers with AsyncId
 
     "work on tests with setup" in {
       val setup = new Setup
-      import setup._
+      import setup.*
 
       "mocked" willBe returned by foo.bar("pepe")
 
@@ -47,7 +47,7 @@ class AsyncIdiomaticMockitoTest extends AsyncWordSpec with Matchers with AsyncId
 
     "work with real future assertions" in {
       val setup = new Setup
-      import setup._
+      import setup.*
 
       val baz = new Baz
 

--- a/scalatest/src/test/scala/user/org/mockito/stubbing/DefaultAnswerTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/stubbing/DefaultAnswerTest.scala
@@ -6,7 +6,7 @@ import org.mockito.stubbing.DefaultAnswer
 import org.scalatest
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ OptionValues, TryValues }
-import user.org.mockito.stubbing.DefaultAnswerTest._
+import user.org.mockito.stubbing.DefaultAnswerTest.*
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/scalaz/src/main/scala/org/mockito/scalaz/EqToEquality.scala
+++ b/scalaz/src/main/scala/org/mockito/scalaz/EqToEquality.scala
@@ -2,7 +2,7 @@ package org.mockito.scalaz
 
 import org.scalactic.Equality
 import scalaz.Equal
-import scalaz.Scalaz._
+import scalaz.Scalaz.*
 
 class EqToEquality[T: Equal] extends Equality[T] {
   override def areEqual(a: T, b: Any): Boolean =

--- a/scalaz/src/main/scala/org/mockito/scalaz/IdiomaticMockitoScalaz.scala
+++ b/scalaz/src/main/scala/org/mockito/scalaz/IdiomaticMockitoScalaz.scala
@@ -1,13 +1,13 @@
 package org.mockito.scalaz
 
 import scalaz.{ Applicative, Equal, MonadError }
-import org.mockito._
+import org.mockito.*
 import org.scalactic.Equality
 
 import scala.reflect.ClassTag
 
 trait IdiomaticMockitoScalaz extends ScalacticSerialisableHack {
-  import org.mockito.scalaz.IdiomaticMockitoScalaz._
+  import org.mockito.scalaz.IdiomaticMockitoScalaz.*
 
   implicit class StubbingOpsScalaz[F[_], T](stubbing: F[T]) {
     def shouldReturnF: ReturnActions[F, T] = macro WhenMacro.shouldReturn[T]
@@ -128,12 +128,12 @@ object IdiomaticMockitoScalaz extends IdiomaticMockitoScalaz {
 
   object Raised
   case class Raised[T]() {
-    def by[F[_], E](stubbing: F[E])(implicit F: MonadError[F, _ >: T]): F[E] = macro DoSomethingMacro.raised[E]
+    def by[F[_], E](stubbing: F[E])(implicit F: MonadError[F, ? >: T]): F[E] = macro DoSomethingMacro.raised[E]
   }
 
   object RaisedG
   case class RaisedG[T]() {
-    def by[F[_], G[_], E](stubbing: F[G[E]])(implicit F: Applicative[F], G: MonadError[G, _ >: T]): F[G[E]] =
+    def by[F[_], G[_], E](stubbing: F[G[E]])(implicit F: Applicative[F], G: MonadError[G, ? >: T]): F[G[E]] =
       macro DoSomethingMacro.raisedG[E]
   }
 
@@ -146,11 +146,11 @@ object IdiomaticMockitoScalaz extends IdiomaticMockitoScalaz {
   }
 
   class ThrowActions[F[_], T](os: ScalazStubbing[F, T]) {
-    def apply[E](error: E)(implicit ae: MonadError[F, _ >: E]): ScalazStubbing[F, T] = os thenFailWith error
+    def apply[E](error: E)(implicit ae: MonadError[F, ? >: E]): ScalazStubbing[F, T] = os thenFailWith error
   }
 
   class ThrowActions2[F[_], G[_], T](os: ScalazStubbing2[F, G, T]) {
-    def apply[E](error: E)(implicit ae: Applicative[F], ag: MonadError[G, _ >: E]): ScalazStubbing2[F, G, T] = os thenFailWith error
+    def apply[E](error: E)(implicit ae: Applicative[F], ag: MonadError[G, ? >: E]): ScalazStubbing2[F, G, T] = os thenFailWith error
   }
 
   class AnswerActions[F[_], T](os: ScalazStubbing[F, T]) {

--- a/scalaz/src/main/scala/org/mockito/scalaz/MockitoScalaz.scala
+++ b/scalaz/src/main/scala/org/mockito/scalaz/MockitoScalaz.scala
@@ -16,25 +16,25 @@ trait MockitoScalaz extends ScalacticSerialisableHack {
   def doReturnF[F[_]: Applicative, T](toBeReturned: T, toBeReturnedNext: T*): Stubber =
     Mockito.doReturn(
       Applicative[F].pure(toBeReturned),
-      toBeReturnedNext.map(Applicative[F].pure(_)).map(_.asInstanceOf[Object]): _*
+      toBeReturnedNext.map(Applicative[F].pure(_)).map(_.asInstanceOf[Object])*
     )
 
   def doReturnFG[F[_]: Applicative, G[_]: Applicative, T](toBeReturned: T, toBeReturnedNext: T*): Stubber =
     Mockito.doReturn(
       Applicative[F].compose[G].pure(toBeReturned),
-      toBeReturnedNext.map(Applicative[F].compose[G].pure(_)).map(_.asInstanceOf[Object]): _*
+      toBeReturnedNext.map(Applicative[F].compose[G].pure(_)).map(_.asInstanceOf[Object])*
     )
 
   def doFailWith[F[_], E, T](error: E, errors: E*)(implicit ae: MonadError[F, E]): Stubber =
     Mockito.doReturn(
       ae.raiseError[T](error),
-      errors.map(e => ae.raiseError[T](e)).map(_.asInstanceOf[Object]): _*
+      errors.map(e => ae.raiseError[T](e)).map(_.asInstanceOf[Object])*
     )
 
   def doFailWithG[F[_]: Applicative, G[_], E, T](error: E, errors: E*)(implicit ae: MonadError[G, E]): Stubber =
     Mockito.doReturn(
       Applicative[F].pure(ae.raiseError[T](error)),
-      errors.map(e => ae.raiseError[T](e)).map(Applicative[F].pure(_)).map(_.asInstanceOf[Object]): _*
+      errors.map(e => ae.raiseError[T](e)).map(Applicative[F].pure(_)).map(_.asInstanceOf[Object])*
     )
 
   def doAnswerF[F[_]: Applicative, R](l: => R): Stubber =
@@ -42,7 +42,7 @@ trait MockitoScalaz extends ScalacticSerialisableHack {
       // Store the param so we don't evaluate the by-name twice
       val _l = l
       _l match {
-        case f: Function0[_] => f()
+        case f: Function0[?] => f()
         case _               => _l
       }
     }.andThen(Applicative[F].pure(_)))
@@ -79,7 +79,7 @@ trait MockitoScalaz extends ScalacticSerialisableHack {
       // Store the param so we don't evaluate the by-name twice
       val _l = l
       _l match {
-        case f: Function0[_] => f()
+        case f: Function0[?] => f()
         case _               => _l
       }
     }.andThen(Applicative[F].compose[G].pure(_)))

--- a/scalaz/src/main/scala/org/mockito/scalaz/ScalazStubbing.scala
+++ b/scalaz/src/main/scala/org/mockito/scalaz/ScalazStubbing.scala
@@ -339,7 +339,7 @@ case class ScalazStubbing[F[_], T](delegate: OngoingStubbing[F[T]]) {
 //             |""".stripMargin)
 //  }
 
-  def thenFailWith[E](error: E)(implicit ae: MonadError[F, _ >: E]): ScalazStubbing[F, T] =
+  def thenFailWith[E](error: E)(implicit ae: MonadError[F, ? >: E]): ScalazStubbing[F, T] =
     delegate thenReturn ae.raiseError[T](error)
 
   def getMock[M]: M = delegate.getMock[M]
@@ -692,7 +692,7 @@ case class ScalazStubbing2[F[_], G[_], T](delegate: OngoingStubbing[F[G[T]]]) {
 //             |""".stripMargin)
 //  }
 
-  def thenFailWith[E](error: E)(implicit ae: Applicative[F], ag: MonadError[G, _ >: E]): ScalazStubbing2[F, G, T] =
+  def thenFailWith[E](error: E)(implicit ae: Applicative[F], ag: MonadError[G, ? >: E]): ScalazStubbing2[F, G, T] =
     delegate thenReturn ae.pure(ag.raiseError[T](error))
 
   def getMock[M]: M = delegate.getMock[M]

--- a/scalaz/src/test/scala/org/mockito/scalaz/DoSomethingScalazTest.scala
+++ b/scalaz/src/test/scala/org/mockito/scalaz/DoSomethingScalazTest.scala
@@ -1,10 +1,10 @@
 package org.mockito.scalaz
 
-import org.mockito._
+import org.mockito.*
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ EitherValues, OptionValues }
-import _root_.scalaz._
-import Scalaz._
+import _root_.scalaz.*
+import Scalaz.*
 import org.mockito.invocation.InvocationOnMock
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/scalaz/src/test/scala/org/mockito/scalaz/IdiomaticMockitoScalazTest.scala
+++ b/scalaz/src/test/scala/org/mockito/scalaz/IdiomaticMockitoScalazTest.scala
@@ -1,9 +1,9 @@
 package org.mockito.scalaz
 
-import _root_.scalaz._
-import Scalaz._
+import _root_.scalaz.*
+import Scalaz.*
 import org.mockito.invocation.InvocationOnMock
-import org.mockito._
+import org.mockito.*
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ EitherValues, OptionValues }
 

--- a/scalaz/src/test/scala/org/mockito/scalaz/MockitoScalazTest.scala
+++ b/scalaz/src/test/scala/org/mockito/scalaz/MockitoScalazTest.scala
@@ -1,9 +1,9 @@
 package org.mockito.scalaz
 
-import _root_.scalaz._
-import Scalaz._
+import _root_.scalaz.*
+import Scalaz.*
 import org.mockito.invocation.InvocationOnMock
-import org.mockito._
+import org.mockito.*
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ EitherValues, OptionValues }
 

--- a/scalaz/src/test/scala/org/mockito/scalaz/package.scala
+++ b/scalaz/src/test/scala/org/mockito/scalaz/package.scala
@@ -1,6 +1,6 @@
 package org.mockito
 
-import _root_.scalaz._
+import _root_.scalaz.*
 
 import scala.concurrent.Future
 

--- a/specs2/src/main/scala/org/mockito/specs2/HamcrestMatcherAdapter.scala
+++ b/specs2/src/main/scala/org/mockito/specs2/HamcrestMatcherAdapter.scala
@@ -19,10 +19,10 @@ case class HamcrestMatcherAdapter[T](m: Matcher[T]) extends BaseMatcher[T] {
   private def matchesSafely[A](item: A, matcher: Matcher[A]): Boolean = {
     // special case for by-name arguments
     // in that case we apply the Function0 to get the value
-    val i = if (item != null && item.isInstanceOf[Function0[_]]) item.asInstanceOf[Function0[_]].apply().asInstanceOf[A] else item
+    val i = if (item != null && item.isInstanceOf[Function0[?]]) item.asInstanceOf[Function0[?]].apply().asInstanceOf[A] else item
     try
       matcher.apply(Expectations.createExpectable(i)) match {
-        case f: MatchFailure[_] => message = f.koMessage; false
+        case f: MatchFailure[?] => message = f.koMessage; false
         case _                  => true
       }
     // a class cast exception can happen if we tried: vet.treat(dog); there must be one(vet).treat(bird) (see issue https://github.com/etorreborre/specs2/issues/222)

--- a/specs2/src/main/scala/org/mockito/specs2/Mockito.scala
+++ b/specs2/src/main/scala/org/mockito/specs2/Mockito.scala
@@ -8,7 +8,7 @@ import org.mockito.stubbing.ScalaOngoingStubbing
 import org.mockito.{ ArgumentMatchersSugar, IdiomaticStubbing, PostfixVerifications, Specs2VerifyMacro, VerifyInOrder, VerifyOrder }
 import org.scalactic.{ Equality, Prettifier }
 import org.specs2.control.Exceptions.catchAll
-import org.specs2.control.Throwablex._
+import org.specs2.control.Throwablex.*
 import org.specs2.matcher.{ Expectable, MatchFailure, MatchResult, MatchSuccess, Matcher }
 
 import scala.reflect.ClassTag
@@ -39,8 +39,8 @@ trait Mockito extends IdiomaticStubbing with PostfixVerifications with ArgumentM
     new DefaultMatcher[T] {
       override def registerDefaultMatcher(value: T): T =
         value match {
-          case m: org.hamcrest.Matcher[_]       => MockitoHamcrest.argThat[T](m.asInstanceOf[org.hamcrest.Matcher[T]])
-          case m: org.specs2.matcher.Matcher[_] => argThat(m)
+          case m: org.hamcrest.Matcher[?]       => MockitoHamcrest.argThat[T](m.asInstanceOf[org.hamcrest.Matcher[T]])
+          case m: org.specs2.matcher.Matcher[?] => argThat(m)
           case _                                => eqTo(value)
         }
     }
@@ -106,7 +106,7 @@ trait Mockito extends IdiomaticStubbing with PostfixVerifications with ArgumentM
   }
 
   implicit class Specs2Stubbing[T](s: ScalaOngoingStubbing[T]) {
-    def thenReturns(value: T, values: T*): ScalaOngoingStubbing[T] = s.andThen(value, values: _*)
+    def thenReturns(value: T, values: T*): ScalaOngoingStubbing[T] = s.andThen(value, values*)
   }
 
   implicit class MatchResultOps[T](m: MatchResult[T]) {
@@ -119,7 +119,7 @@ trait Mockito extends IdiomaticStubbing with PostfixVerifications with ArgumentM
 
   def inOrder(mocks: AnyRef*) =
     VerifyInOrder(mocks.toList.flatMap {
-      case i: Array[_] => i.asInstanceOf[Array[AnyRef]]
+      case i: Array[?] => i.asInstanceOf[Array[AnyRef]]
       case m           => List(m)
     })
 }

--- a/specs2/src/main/scala/org/mockito/specs2/MockitoSpecs2Support.scala
+++ b/specs2/src/main/scala/org/mockito/specs2/MockitoSpecs2Support.scala
@@ -1,6 +1,6 @@
 package org.mockito.specs2
 
-import org.specs2.matcher.MatchersImplicits._
+import org.specs2.matcher.MatchersImplicits.*
 import org.specs2.matcher.{ BeEqualTo, Expectations, MatchFailure, Matcher }
 
 trait ArgThat {

--- a/specs2/src/test/scala/org/mockito/specs2/MockitoScalaNewSyntaxSpec.scala
+++ b/specs2/src/test/scala/org/mockito/specs2/MockitoScalaNewSyntaxSpec.scala
@@ -8,18 +8,18 @@ import org.mockito.{ VerifyInOrder, VerifyOrder }
 import org.mockito.captor.ArgCaptor
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.DefaultAnswer
-import org.specs2._
-import org.specs2.control.Exceptions._
-import org.specs2.execute._
-import org.specs2.fp.syntax._
-import org.specs2.matcher.ActionMatchers._
-import org.specs2.matcher.MatchersImplicits._
-import org.specs2.matcher._
-import org.specs2.specification.core.{ Env, _ }
-import org.specs2.specification.process._
+import org.specs2.*
+import org.specs2.control.Exceptions.*
+import org.specs2.execute.*
+import org.specs2.fp.syntax.*
+import org.specs2.matcher.ActionMatchers.*
+import org.specs2.matcher.MatchersImplicits.*
+import org.specs2.matcher.*
+import org.specs2.specification.core.{ Env, * }
+import org.specs2.specification.process.*
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class MockitoScalaNewSyntaxSpec extends Spec with Mockito {
   def is = s2"""
@@ -214,63 +214,63 @@ The Mockito trait is reusable in other contexts
   }
 
   def verification6 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     byname.call(10)
     byname.call(10) was called
   }
 
   def verification7 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     byname.add(1, 2)
     byname.add(1, 2) was called
   }
 
   def verification8 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     byname.mult(1)(2)
     byname.mult(1)(2) was called
   }
 
   def verification9 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     byname.call(10)
     byname.call(be_>(5)) was called
   }
 
   def verification10 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     byname.add(1, 2)
     byname.add(anyInt, anyInt) was called
   }
 
   def verification11 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     byname.min(2, 1)
     byname.min(anyInt, anyInt) was called
   }
 
   def verification12 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     byname.mult(1)(2)
     byname.mult(anyInt)(anyInt) was called
   }
 
   def verification13 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     function1.call((_: Int).toString)
     function1.call(1 -> "1") was called
   }
 
   def verification14 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     function1.call((_: Int).toString)
     (function1.call(1 -> startWith("1")) was called) and
@@ -278,70 +278,70 @@ The Mockito trait is reusable in other contexts
   }
 
   def verification15 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     function2.call((i: Int, d: Double) => (i + d).toString)
     function2.call((1, 3.0) -> "4.0") was called
   }
 
   def verification16 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     function2.call((i: Int, d: Double) => (i + d).toString)
     function2.call((1, 3.0) -> haveSize[String](3)) was called
   }
 
   def verification17 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     function2.call((i: Int, d: Double) => (i + d).toString)
     function2.call(*) was called
   }
 
   def verification18 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     functionNothing.call((_: Int) => throw new Exception)
     functionNothing.call(*) was called
   }
 
   def verification19 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     functionAny.call(() => throw new Exception)
     functionAny.call(any[() => Any]) was called
   }
 
   def verification20 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     partial.call { case (i: Int, d: Double) => (i + d).toString }
     partial.call((1, 3.0) -> "4.0") was called
   }
 
   def verification21 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     partial.call { case (i: Int, d: Double) => (i + d).toString }
     partial.call((1, 3.0) -> haveSize[String](3)) was called
   }
 
   def verification22 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     partial.call { case (i: Int, d: Double) => (i + d).toString }
     partial.call(*) was called
   }
 
   def verification23 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     partial.call { case (i: Int, d: Double) if i > 10 => (i + d).toString }
     (partial.call((1, 3.0) -> "4.0") was called).message must contain("a PartialFunction defined for (1,3.0)")
   }
 
   def verification24 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     repeated.call(1, 2, 3)
     (repeated.call(1, 2, 3) was called) and
@@ -349,7 +349,7 @@ The Mockito trait is reusable in other contexts
   }
 
   def verification26 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     functionInt.call((i: Int) => i + 2)
     (functionInt.call(Map(1 -> 2)) was called).message must contain("Argument(s) are different")

--- a/specs2/src/test/scala/org/mockito/specs2/MockitoScalaSpec.scala
+++ b/specs2/src/test/scala/org/mockito/specs2/MockitoScalaSpec.scala
@@ -7,18 +7,18 @@ import org.mockito.{ VerifyInOrder, VerifyOrder }
 import org.mockito.captor.ArgCaptor
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.DefaultAnswer
-import org.specs2._
-import org.specs2.control.Exceptions._
-import org.specs2.execute._
-import org.specs2.fp.syntax._
-import org.specs2.matcher.ActionMatchers._
-import org.specs2.matcher.MatchersImplicits._
-import org.specs2.matcher._
-import org.specs2.specification.core.{ Env, _ }
-import org.specs2.specification.process._
+import org.specs2.*
+import org.specs2.control.Exceptions.*
+import org.specs2.execute.*
+import org.specs2.fp.syntax.*
+import org.specs2.matcher.ActionMatchers.*
+import org.specs2.matcher.MatchersImplicits.*
+import org.specs2.matcher.*
+import org.specs2.specification.core.{ Env, * }
+import org.specs2.specification.process.*
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 
 class MockitoScalaSpec extends Spec with Mockito {
   def is = s2"""
@@ -213,63 +213,63 @@ The Mockito trait is reusable in other contexts
   }
 
   def verification6 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     byname.call(10)
     there was one(byname).call(10)
   }
 
   def verification7 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     byname.add(1, 2)
     there was one(byname).add(1, 2)
   }
 
   def verification8 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     byname.mult(1)(2)
     there was one(byname).mult(1)(2)
   }
 
   def verification9 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     byname.call(10)
     there was one(byname).call(be_>(5))
   }
 
   def verification10 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     byname.add(1, 2)
     there was one(byname).add(anyInt, anyInt)
   }
 
   def verification11 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     byname.min(2, 1)
     there was one(byname).min(anyInt, anyInt)
   }
 
   def verification12 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     byname.mult(1)(2)
     there was one(byname).mult(anyInt)(anyInt)
   }
 
   def verification13 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     function1.call((_: Int).toString)
     there was one(function1).call(1 -> "1")
   }
 
   def verification14 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     function1.call((_: Int).toString)
     (there was one(function1).call(1 -> startWith("1"))) and
@@ -277,70 +277,70 @@ The Mockito trait is reusable in other contexts
   }
 
   def verification15 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     function2.call((i: Int, d: Double) => (i + d).toString)
     there was one(function2).call((1, 3.0) -> "4.0")
   }
 
   def verification16 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     function2.call((i: Int, d: Double) => (i + d).toString)
     there was one(function2).call((1, 3.0) -> haveSize[String](3))
   }
 
   def verification17 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     function2.call((i: Int, d: Double) => (i + d).toString)
     there was one(function2).call(*)
   }
 
   def verification18 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     functionNothing.call((_: Int) => throw new Exception)
     there was one(functionNothing).call(*)
   }
 
   def verification19 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     functionAny.call(() => throw new Exception)
     there was one(functionAny).call(any[() => Any])
   }
 
   def verification20 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     partial.call { case (i: Int, d: Double) => (i + d).toString }
     there was one(partial).call((1, 3.0) -> "4.0")
   }
 
   def verification21 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     partial.call { case (i: Int, d: Double) => (i + d).toString }
     there was one(partial).call((1, 3.0) -> haveSize[String](3))
   }
 
   def verification22 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     partial.call { case (i: Int, d: Double) => (i + d).toString }
     there was one(partial).call(*)
   }
 
   def verification23 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     partial.call { case (i: Int, d: Double) if i > 10 => (i + d).toString }
     (there was one(partial).call((1, 3.0) -> "4.0")).message must contain("a PartialFunction defined for (1,3.0)")
   }
 
   def verification24 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     repeated.call(1, 2, 3)
     (there was one(repeated).call(1, 2, 3)) and
@@ -348,7 +348,7 @@ The Mockito trait is reusable in other contexts
   }
 
   def verification26 = {
-    object list extends list; import list._
+    object list extends list; import list.*
 
     functionInt.call((i: Int) => i + 2)
     (there was one(functionInt).call(Map(1 -> 2))).message must contain("Argument(s) are different")


### PR DESCRIPTION
Also:
- adds `rewrite.scala3.convertToNewSyntax = true` to **.scalafmt.conf**
- applies formatting changes.

Preliminary step for #364.
