### PR TITLE
Refactor: extract ValueClassExtractor/Wrapper macros to scala-2 sources

### DIFF
--- a/macro-common/src/main/scala-2/org/mockito/internal/ValueClassExtractorMacro.scala
+++ b/macro-common/src/main/scala-2/org/mockito/internal/ValueClassExtractorMacro.scala
@@ -1,0 +1,31 @@
+package org.mockito.internal
+
+import org.mockito.internal.MacroDebug.debugResult
+
+import scala.reflect.macros.blackbox
+
+/**
+ * Scala 2 macro implementation for ValueClassExtractor.
+ */
+trait ValueClassExtractorCompat {
+  implicit def instance[VC]: ValueClassExtractor[VC] = macro ValueClassExtractorMacro.materialise[VC]
+}
+
+object ValueClassExtractorMacro {
+  def materialise[VC: c.WeakTypeTag](c: blackbox.Context): c.Expr[ValueClassExtractor[VC]] = {
+    import c.universe.*
+    val tpe          = weakTypeOf[VC]
+    val typeSymbol   = tpe.typeSymbol
+    val isValueClass = typeSymbol.isClass && typeSymbol.asClass.isDerivedValueClass
+
+    val r =
+      if (isValueClass) {
+        c.Expr[ValueClassExtractor[VC]](q"new _root_.org.mockito.internal.ReflectionExtractor[$tpe]")
+      } else
+        c.Expr[ValueClassExtractor[VC]](q"new _root_.org.mockito.internal.NormalClassExtractor[$tpe]")
+
+    debugResult(c)("mockito-print-extractor")(r.tree)
+
+    r
+  }
+}

--- a/macro-common/src/main/scala-2/org/mockito/internal/ValueClassWrapperMacro.scala
+++ b/macro-common/src/main/scala-2/org/mockito/internal/ValueClassWrapperMacro.scala
@@ -1,0 +1,29 @@
+package org.mockito.internal
+
+import scala.reflect.macros.blackbox
+
+/**
+ * Scala 2 macro implementation for ValueClassWrapper.
+ */
+trait ValueClassWrapperCompat {
+  implicit def instance[VC]: ValueClassWrapper[VC] = macro ValueClassWrapperMacro.materialise[VC]
+}
+
+object ValueClassWrapperMacro {
+  def materialise[VC: c.WeakTypeTag](c: blackbox.Context): c.Expr[ValueClassWrapper[VC]] = {
+    import c.universe.*
+    val tpe          = weakTypeOf[VC]
+    val typeSymbol   = tpe.typeSymbol
+    val isValueClass = typeSymbol.isClass && typeSymbol.asClass.isDerivedValueClass
+
+    val r =
+      if (isValueClass)
+        c.Expr[ValueClassWrapper[VC]](q"new _root_.org.mockito.internal.ReflectionWrapper[$tpe]")
+      else
+        c.Expr[ValueClassWrapper[VC]](q"new _root_.org.mockito.internal.NormalClassWrapper[$tpe]")
+
+    MacroDebug.debugResult(c)("mockito-print-wrapper")(r.tree)
+
+    r
+  }
+}

--- a/macro-common/src/main/scala/org/mockito/internal/ValueClassExtractor.scala
+++ b/macro-common/src/main/scala/org/mockito/internal/ValueClassExtractor.scala
@@ -1,10 +1,5 @@
 package org.mockito.internal
 
-import org.mockito.internal.MacroDebug.debugResult
-import org.mockito.internal.ScalaVersion.{ V2_12, V2_13 }
-
-import scala.reflect.macros.blackbox
-
 trait ValueClassExtractor[VC] extends Serializable {
   def isValueClass: Boolean = true
   def extract(vc: VC): Any
@@ -27,28 +22,6 @@ class ReflectionExtractor[VC] extends ValueClassExtractor[VC] {
   }
 }
 
-object ValueClassExtractor {
+object ValueClassExtractor extends ValueClassExtractorCompat {
   def apply[T: ValueClassExtractor]: ValueClassExtractor[T] = implicitly[ValueClassExtractor[T]]
-
-  implicit def instance[VC]: ValueClassExtractor[VC] = macro materialise[VC]
-
-  def materialise[VC: c.WeakTypeTag](c: blackbox.Context): c.Expr[ValueClassExtractor[VC]] = {
-    import c.universe.*
-    val tpe          = weakTypeOf[VC]
-    val typeSymbol   = tpe.typeSymbol
-    val isValueClass = typeSymbol.isClass && typeSymbol.asClass.isDerivedValueClass
-
-    val r =
-      if (isValueClass) {
-        ScalaVersion.Current match {
-          case V2_12 | V2_13 =>
-            c.Expr[ValueClassExtractor[VC]](q"new _root_.org.mockito.internal.ReflectionExtractor[$tpe]")
-        }
-      } else
-        c.Expr[ValueClassExtractor[VC]](q"new _root_.org.mockito.internal.NormalClassExtractor[$tpe]")
-
-    debugResult(c)("mockito-print-extractor")(r.tree)
-
-    r
-  }
 }

--- a/macro-common/src/main/scala/org/mockito/internal/ValueClassWrapper.scala
+++ b/macro-common/src/main/scala/org/mockito/internal/ValueClassWrapper.scala
@@ -1,9 +1,6 @@
 package org.mockito.internal
 
-import org.mockito.internal.MacroDebug.debugResult
-
 import scala.reflect.ClassTag
-import scala.reflect.macros.blackbox
 
 trait ValueClassWrapper[VC] extends Serializable {
   def isValueClass: Boolean = true
@@ -27,25 +24,6 @@ class ReflectionWrapper[VC: ClassTag] extends ValueClassWrapper[VC] {
       .getOrElse(throw new RuntimeException(s"Can't find a constructor for $clazz that takes a single param"))
 }
 
-object ValueClassWrapper {
+object ValueClassWrapper extends ValueClassWrapperCompat {
   def apply[T: ValueClassWrapper]: ValueClassWrapper[T] = implicitly[ValueClassWrapper[T]]
-
-  implicit def instance[VC]: ValueClassWrapper[VC] = macro materialise[VC]
-
-  def materialise[VC: c.WeakTypeTag](c: blackbox.Context): c.Expr[ValueClassWrapper[VC]] = {
-    import c.universe.*
-    val tpe          = weakTypeOf[VC]
-    val typeSymbol   = tpe.typeSymbol
-    val isValueClass = typeSymbol.isClass && typeSymbol.asClass.isDerivedValueClass
-
-    val r =
-      if (isValueClass)
-        c.Expr[ValueClassWrapper[VC]](q"new _root_.org.mockito.internal.ReflectionWrapper[$tpe]")
-      else
-        c.Expr[ValueClassWrapper[VC]](q"new _root_.org.mockito.internal.NormalClassWrapper[$tpe]")
-
-    debugResult(c)("mockito-print-wrapper")(r.tree)
-
-    r
-  }
 }


### PR DESCRIPTION
Another baby step toward Scala 3
Move Scala 2 macro implementations from shared ValueClassExtractor and ValueClassWrapper into dedicated scala-2/ source files. The shared files now contain only runtime types and delegate to a Compat trait that provides the implicit macro in Scala 2.