### PR TITLE
Refactor: extract MacroConstants from Utils

### DIFF
--- a/macro/src/main/scala/org/mockito/MacroConstants.scala
+++ b/macro/src/main/scala/org/mockito/MacroConstants.scala
@@ -1,0 +1,62 @@
+package org.mockito
+
+import scala.util.matching.Regex
+
+/**
+ * Constants used by macro implementations. Shared across Scala 2 and Scala 3.
+ */
+object MacroConstants {
+
+  val MockitoMatchers: Set[String] = Set(
+    "anyByte",
+    "anyBoolean",
+    "anyChar",
+    "anyDouble",
+    "anyInt",
+    "anyFloat",
+    "anyShort",
+    "anyLong",
+    "anyList",
+    "anySeq",
+    "anyIterable",
+    "anySet",
+    "anyMap",
+    "any",
+    "anyVal",
+    "$times", // *
+    "isNull",
+    "isNotNull",
+    "eqTo",
+    "eqToVal",
+    "same",
+    "isA",
+    "refEq",
+    "function0",
+    "matches",
+    "startsWith",
+    "contains",
+    "endsWith",
+    "argThat",
+    "byteThat",
+    "booleanThat",
+    "charThat",
+    "doubleThat",
+    "intThat",
+    "floatThat",
+    "shortThat",
+    "longThat",
+    "argMatching",
+    "$greater",    // >
+    "$greater$eq", // >=
+    "$less",       // <
+    "$less$eq",    // <=
+    "$eq$tilde",   // =~
+    "Captor.asCapture",
+    "capture"
+  )
+
+  private val Specs2Implicits: Regex = "(matcher)?[t,T]o(Partial)?FunctionCall(\\d*)".r
+
+  def isSpecs2Matcher(methodName: String): Boolean =
+    Specs2Implicits.pattern.matcher(methodName).matches
+}

--- a/macro/src/main/scala/org/mockito/Utils.scala
+++ b/macro/src/main/scala/org/mockito/Utils.scala
@@ -1,61 +1,12 @@
 package org.mockito
+
+import org.mockito.MacroConstants.{ isSpecs2Matcher, MockitoMatchers }
+
 import scala.reflect.macros.blackbox
-import scala.util.matching.Regex
 
 object Utils {
   private[mockito] def hasMatchers(c: blackbox.Context)(args: List[c.Tree]): Boolean =
     args.exists(arg => isMatcher(c)(arg))
-
-  private val MockitoMatchers = Set(
-    "anyByte",
-    "anyBoolean",
-    "anyChar",
-    "anyDouble",
-    "anyInt",
-    "anyFloat",
-    "anyShort",
-    "anyLong",
-    "anyList",
-    "anySeq",
-    "anyIterable",
-    "anySet",
-    "anyMap",
-    "any",
-    "anyVal",
-    "$times", // *
-    "isNull",
-    "isNotNull",
-    "eqTo",
-    "eqToVal",
-    "same",
-    "isA",
-    "refEq",
-    "function0",
-    "matches",
-    "startsWith",
-    "contains",
-    "endsWith",
-    "argThat",
-    "byteThat",
-    "booleanThat",
-    "charThat",
-    "doubleThat",
-    "intThat",
-    "floatThat",
-    "shortThat",
-    "longThat",
-    "argMatching",
-    "$greater",    // >
-    "$greater$eq", // >=
-    "$less",       // <
-    "$less$eq",    // <=
-    "$eq$tilde",   // =~
-    "Captor.asCapture",
-    "capture"
-  )
-
-  private val specs2implicits: Regex                       = "(matcher)?[t,T]o(Partial)?FunctionCall(\\d*)".r
-  private def isSpecs2Matcher(methodName: String): Boolean = specs2implicits.pattern.matcher(methodName).matches
 
   private[mockito] def isMatcher(c: blackbox.Context)(arg: c.Tree): Boolean = {
     import c.universe.*


### PR DESCRIPTION
Another baby step toward Scala 3, extracting some constants from scala-2 macro heavy Utils class