### PR TITLE
Refactor: extract macro runtime classes to shared files

### DIFF
--- a/macro/src/main/scala/org/mockito/VerifyMacro.scala
+++ b/macro/src/main/scala/org/mockito/VerifyMacro.scala
@@ -2,8 +2,6 @@ package org.mockito
 
 import org.mockito.Utils.*
 import org.mockito.internal.MacroDebug.debugResult
-import org.mockito.internal.verification.VerificationModeFactory
-import org.mockito.verification.VerificationMode
 
 import scala.reflect.macros.blackbox
 
@@ -12,6 +10,11 @@ object Called {
 }
 
 object VerifyMacro extends VerificationMacroTransformer {
+  // Re-export runtime objects so existing code referencing VerifyMacro.* continues to work
+  val Never      = VerifyMacroRuntime.Never
+  val NeverAgain = VerifyMacroRuntime.NeverAgain
+  val Once       = VerifyMacroRuntime.Once
+
   def wasMacro[T: c.WeakTypeTag, R](c: blackbox.Context)(called: c.Tree)(order: c.Expr[VerifyOrder]): c.Expr[R] = {
     val r = c.Expr[R](transformVerification(c)(c.macroApplication))
     debugResult(c)("mockito-print-verify")(r.tree)
@@ -22,18 +25,6 @@ object VerifyMacro extends VerificationMacroTransformer {
     val r = c.Expr[R](transformVerification(c)(c.macroApplication))
     debugResult(c)("mockito-print-verify")(r.tree)
     r
-  }
-
-  object Never extends ScalaVerificationMode {
-    override def verificationMode: VerificationMode = Mockito.never
-  }
-
-  object NeverAgain extends ScalaVerificationMode {
-    override def verificationMode: VerificationMode = VerificationModeFactory.noMoreInteractions()
-  }
-
-  object Once extends ScalaVerificationMode {
-    override def verificationMode: VerificationMode = Mockito.times(1)
   }
 
 }
@@ -100,7 +91,7 @@ private[mockito] trait VerificationMacroTransformer {
 
     called match {
       case q"$_.VerifyingOps[$_]($invocation).was($_.called)($order)" =>
-        transformInvocation(c)(invocation, order, q"_root_.org.mockito.VerifyMacro.Once")
+        transformInvocation(c)(invocation, order, q"_root_.org.mockito.VerifyMacroRuntime.Once")
 
       case q"$_.VerifyingOps[$_]($a.$b).wasNever($called)($order)" =>
         q"""
@@ -115,7 +106,7 @@ private[mockito] trait VerificationMacroTransformer {
                 ""
               ).mkString("\n"))
              """
-            case _ => transformInvocation(c)(q"$a.$b", order, q"_root_.org.mockito.VerifyMacro.Never")
+            case _ => transformInvocation(c)(q"$a.$b", order, q"_root_.org.mockito.VerifyMacroRuntime.Never")
           }}
           } else { 
             ${transformMockWasNeverCalled(q"$a.$b", called)}
@@ -123,7 +114,7 @@ private[mockito] trait VerificationMacroTransformer {
          """
 
       case q"$_.VerifyingOps[$_]($obj.$method[..$targs](...$args)).wasNever($_.called)($order)" =>
-        transformInvocation(c)(q"$obj.$method[..$targs](...$args)", order, q"_root_.org.mockito.VerifyMacro.Never")
+        transformInvocation(c)(q"$obj.$method[..$targs](...$args)", order, q"_root_.org.mockito.VerifyMacroRuntime.Never")
 
       case q"$_.VerifyingOps[$_]($obj).wasNever($called)($_)" =>
         transformMockWasNeverCalled(obj, called)
@@ -136,28 +127,3 @@ private[mockito] trait VerificationMacroTransformer {
   }
 }
 
-trait ScalaVerificationMode {
-  def verificationMode: VerificationMode
-}
-
-sealed trait VerifyOrder {
-  def verify[T](mock: T): T
-  def verifyWithMode[T](mock: T, mode: ScalaVerificationMode): T
-}
-
-object VerifyUnOrdered extends VerifyOrder {
-  override def verify[T](mock: T): T                                      = Mockito.verify(mock)
-  override def verifyWithMode[T](mock: T, mode: ScalaVerificationMode): T = Mockito.verify(mock, mode.verificationMode)
-}
-
-case class VerifyInOrder(mocks: Seq[AnyRef]) extends VerifyOrder {
-  private val _inOrder = Mockito.inOrder(mocks*)
-
-  override def verify[T](mock: T): T                                      = _inOrder.verify(mock)
-  override def verifyWithMode[T](mock: T, mode: ScalaVerificationMode): T = _inOrder.verify(mock, mode.verificationMode)
-  def verifyNoMoreInteractions(): Unit                                    = _inOrder.verifyNoMoreInteractions()
-}
-
-object VerifyOrder {
-  implicit val unOrdered: VerifyOrder = VerifyUnOrdered
-}

--- a/macro/src/main/scala/org/mockito/VerifyMacroRuntime.scala
+++ b/macro/src/main/scala/org/mockito/VerifyMacroRuntime.scala
@@ -1,0 +1,48 @@
+package org.mockito
+
+import org.mockito.internal.verification.VerificationModeFactory
+import org.mockito.verification.VerificationMode
+
+/**
+ * Runtime support classes for VerifyMacro. These classes are used by macro-generated code and shared across Scala 2 and Scala 3.
+ */
+object VerifyMacroRuntime {
+
+  object Never extends ScalaVerificationMode {
+    override def verificationMode: VerificationMode = Mockito.never
+  }
+
+  object NeverAgain extends ScalaVerificationMode {
+    override def verificationMode: VerificationMode = VerificationModeFactory.noMoreInteractions()
+  }
+
+  object Once extends ScalaVerificationMode {
+    override def verificationMode: VerificationMode = Mockito.times(1)
+  }
+}
+
+trait ScalaVerificationMode {
+  def verificationMode: VerificationMode
+}
+
+sealed trait VerifyOrder {
+  def verify[T](mock: T): T
+  def verifyWithMode[T](mock: T, mode: ScalaVerificationMode): T
+}
+
+object VerifyUnOrdered extends VerifyOrder {
+  override def verify[T](mock: T): T                                      = Mockito.verify(mock)
+  override def verifyWithMode[T](mock: T, mode: ScalaVerificationMode): T = Mockito.verify(mock, mode.verificationMode)
+}
+
+case class VerifyInOrder(mocks: Seq[AnyRef]) extends VerifyOrder {
+  private val _inOrder = Mockito.inOrder(mocks*)
+
+  override def verify[T](mock: T): T                                      = _inOrder.verify(mock)
+  override def verifyWithMode[T](mock: T, mode: ScalaVerificationMode): T = _inOrder.verify(mock, mode.verificationMode)
+  def verifyNoMoreInteractions(): Unit                                    = _inOrder.verifyNoMoreInteractions()
+}
+
+object VerifyOrder {
+  implicit val unOrdered: VerifyOrder = VerifyUnOrdered
+}

--- a/macro/src/main/scala/org/mockito/WhenMacro.scala
+++ b/macro/src/main/scala/org/mockito/WhenMacro.scala
@@ -2,13 +2,16 @@ package org.mockito
 
 import org.mockito.Utils.*
 import org.mockito.internal.MacroDebug.debugResult
-import org.mockito.internal.ValueClassWrapper
 import org.mockito.stubbing.{ ScalaFirstStubbing, ScalaOngoingStubbing }
 
-import scala.reflect.ClassTag
 import scala.reflect.macros.blackbox
 
 object WhenMacro {
+  // Re-export runtime classes so existing code referencing WhenMacro.* continues to work
+  type AnswerActions[T]   = WhenMacroRuntime.AnswerActions[T]
+  type AnswerPFActions[T] = WhenMacroRuntime.AnswerPFActions[T]
+  val RealMethod = WhenMacroRuntime.RealMethod
+
   private def transformInvocation(c: blackbox.Context)(invocation: c.Tree): c.Tree = {
     import c.universe.*
 
@@ -84,10 +87,6 @@ object WhenMacro {
     r
   }
 
-  object RealMethod {
-    def willBe(called: Called.type): Called.type = called
-  }
-
   val ShouldCallOptions                                                                                                          = Set("shouldCall", "mustCall", "calls")
   def shouldCallRealMethod[T: c.WeakTypeTag](c: blackbox.Context)(crm: c.Expr[RealMethod.type]): c.Expr[ScalaOngoingStubbing[T]] = {
     import c.universe.*
@@ -126,330 +125,6 @@ object WhenMacro {
     r
   }
 
-  class AnswerActions[T](os: ScalaFirstStubbing[T]) {
-    def apply(f: => T): ScalaOngoingStubbing[T] = os thenAnswer f
-
-    def apply[P0: ValueClassWrapper](f: P0 => T)(implicit classTag: ClassTag[P0] = defaultClassTag[P0]): ScalaOngoingStubbing[T] =
-      os thenAnswer f
-
-    def apply[P0: ValueClassWrapper, P1: ValueClassWrapper](f: (P0, P1) => T): ScalaOngoingStubbing[T] =
-      os thenAnswer f
-
-    def apply[P0: ValueClassWrapper, P1: ValueClassWrapper, P2: ValueClassWrapper](f: (P0, P1, P2) => T): ScalaOngoingStubbing[T] =
-      os thenAnswer f
-
-    def apply[P0: ValueClassWrapper, P1: ValueClassWrapper, P2: ValueClassWrapper, P3: ValueClassWrapper](f: (P0, P1, P2, P3) => T): ScalaOngoingStubbing[T] =
-      os thenAnswer f
-
-    def apply[P0: ValueClassWrapper, P1: ValueClassWrapper, P2: ValueClassWrapper, P3: ValueClassWrapper, P4: ValueClassWrapper](
-        f: (P0, P1, P2, P3, P4) => T
-    ): ScalaOngoingStubbing[T] =
-      os thenAnswer f
-
-    def apply[P0: ValueClassWrapper, P1: ValueClassWrapper, P2: ValueClassWrapper, P3: ValueClassWrapper, P4: ValueClassWrapper, P5: ValueClassWrapper](
-        f: (P0, P1, P2, P3, P4, P5) => T
-    ): ScalaOngoingStubbing[T] =
-      os thenAnswer f
-
-    def apply[P0: ValueClassWrapper, P1: ValueClassWrapper, P2: ValueClassWrapper, P3: ValueClassWrapper, P4: ValueClassWrapper, P5: ValueClassWrapper, P6: ValueClassWrapper](
-        f: (P0, P1, P2, P3, P4, P5, P6) => T
-    ): ScalaOngoingStubbing[T] =
-      os thenAnswer f
-
-    def apply[
-        P0: ValueClassWrapper,
-        P1: ValueClassWrapper,
-        P2: ValueClassWrapper,
-        P3: ValueClassWrapper,
-        P4: ValueClassWrapper,
-        P5: ValueClassWrapper,
-        P6: ValueClassWrapper,
-        P7: ValueClassWrapper
-    ](f: (P0, P1, P2, P3, P4, P5, P6, P7) => T): ScalaOngoingStubbing[T] =
-      os thenAnswer f
-
-    def apply[
-        P0: ValueClassWrapper,
-        P1: ValueClassWrapper,
-        P2: ValueClassWrapper,
-        P3: ValueClassWrapper,
-        P4: ValueClassWrapper,
-        P5: ValueClassWrapper,
-        P6: ValueClassWrapper,
-        P7: ValueClassWrapper,
-        P8: ValueClassWrapper
-    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8) => T): ScalaOngoingStubbing[T] =
-      os thenAnswer f
-
-    def apply[
-        P0: ValueClassWrapper,
-        P1: ValueClassWrapper,
-        P2: ValueClassWrapper,
-        P3: ValueClassWrapper,
-        P4: ValueClassWrapper,
-        P5: ValueClassWrapper,
-        P6: ValueClassWrapper,
-        P7: ValueClassWrapper,
-        P8: ValueClassWrapper,
-        P9: ValueClassWrapper
-    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9) => T): ScalaOngoingStubbing[T] =
-      os thenAnswer f
-
-    def apply[
-        P0: ValueClassWrapper,
-        P1: ValueClassWrapper,
-        P2: ValueClassWrapper,
-        P3: ValueClassWrapper,
-        P4: ValueClassWrapper,
-        P5: ValueClassWrapper,
-        P6: ValueClassWrapper,
-        P7: ValueClassWrapper,
-        P8: ValueClassWrapper,
-        P9: ValueClassWrapper,
-        P10: ValueClassWrapper
-    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) => T): ScalaOngoingStubbing[T] =
-      os thenAnswer f
-
-    def apply[
-        P0: ValueClassWrapper,
-        P1: ValueClassWrapper,
-        P2: ValueClassWrapper,
-        P3: ValueClassWrapper,
-        P4: ValueClassWrapper,
-        P5: ValueClassWrapper,
-        P6: ValueClassWrapper,
-        P7: ValueClassWrapper,
-        P8: ValueClassWrapper,
-        P9: ValueClassWrapper,
-        P10: ValueClassWrapper,
-        P11: ValueClassWrapper
-    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11) => T): ScalaOngoingStubbing[T] =
-      os thenAnswer f
-
-    def apply[
-        P0: ValueClassWrapper,
-        P1: ValueClassWrapper,
-        P2: ValueClassWrapper,
-        P3: ValueClassWrapper,
-        P4: ValueClassWrapper,
-        P5: ValueClassWrapper,
-        P6: ValueClassWrapper,
-        P7: ValueClassWrapper,
-        P8: ValueClassWrapper,
-        P9: ValueClassWrapper,
-        P10: ValueClassWrapper,
-        P11: ValueClassWrapper,
-        P12: ValueClassWrapper
-    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12) => T): ScalaOngoingStubbing[T] =
-      os thenAnswer f
-
-    def apply[
-        P0: ValueClassWrapper,
-        P1: ValueClassWrapper,
-        P2: ValueClassWrapper,
-        P3: ValueClassWrapper,
-        P4: ValueClassWrapper,
-        P5: ValueClassWrapper,
-        P6: ValueClassWrapper,
-        P7: ValueClassWrapper,
-        P8: ValueClassWrapper,
-        P9: ValueClassWrapper,
-        P10: ValueClassWrapper,
-        P11: ValueClassWrapper,
-        P12: ValueClassWrapper,
-        P13: ValueClassWrapper
-    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13) => T): ScalaOngoingStubbing[T] =
-      os thenAnswer f
-
-    def apply[
-        P0: ValueClassWrapper,
-        P1: ValueClassWrapper,
-        P2: ValueClassWrapper,
-        P3: ValueClassWrapper,
-        P4: ValueClassWrapper,
-        P5: ValueClassWrapper,
-        P6: ValueClassWrapper,
-        P7: ValueClassWrapper,
-        P8: ValueClassWrapper,
-        P9: ValueClassWrapper,
-        P10: ValueClassWrapper,
-        P11: ValueClassWrapper,
-        P12: ValueClassWrapper,
-        P13: ValueClassWrapper,
-        P14: ValueClassWrapper
-    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14) => T): ScalaOngoingStubbing[T] =
-      os thenAnswer f
-
-    def apply[
-        P0: ValueClassWrapper,
-        P1: ValueClassWrapper,
-        P2: ValueClassWrapper,
-        P3: ValueClassWrapper,
-        P4: ValueClassWrapper,
-        P5: ValueClassWrapper,
-        P6: ValueClassWrapper,
-        P7: ValueClassWrapper,
-        P8: ValueClassWrapper,
-        P9: ValueClassWrapper,
-        P10: ValueClassWrapper,
-        P11: ValueClassWrapper,
-        P12: ValueClassWrapper,
-        P13: ValueClassWrapper,
-        P14: ValueClassWrapper,
-        P15: ValueClassWrapper
-    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15) => T): ScalaOngoingStubbing[T] =
-      os thenAnswer f
-
-    def apply[
-        P0: ValueClassWrapper,
-        P1: ValueClassWrapper,
-        P2: ValueClassWrapper,
-        P3: ValueClassWrapper,
-        P4: ValueClassWrapper,
-        P5: ValueClassWrapper,
-        P6: ValueClassWrapper,
-        P7: ValueClassWrapper,
-        P8: ValueClassWrapper,
-        P9: ValueClassWrapper,
-        P10: ValueClassWrapper,
-        P11: ValueClassWrapper,
-        P12: ValueClassWrapper,
-        P13: ValueClassWrapper,
-        P14: ValueClassWrapper,
-        P15: ValueClassWrapper,
-        P16: ValueClassWrapper
-    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16) => T): ScalaOngoingStubbing[T] =
-      os thenAnswer f
-
-    def apply[
-        P0: ValueClassWrapper,
-        P1: ValueClassWrapper,
-        P2: ValueClassWrapper,
-        P3: ValueClassWrapper,
-        P4: ValueClassWrapper,
-        P5: ValueClassWrapper,
-        P6: ValueClassWrapper,
-        P7: ValueClassWrapper,
-        P8: ValueClassWrapper,
-        P9: ValueClassWrapper,
-        P10: ValueClassWrapper,
-        P11: ValueClassWrapper,
-        P12: ValueClassWrapper,
-        P13: ValueClassWrapper,
-        P14: ValueClassWrapper,
-        P15: ValueClassWrapper,
-        P16: ValueClassWrapper,
-        P17: ValueClassWrapper
-    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17) => T): ScalaOngoingStubbing[T] =
-      os thenAnswer f
-
-    def apply[
-        P0: ValueClassWrapper,
-        P1: ValueClassWrapper,
-        P2: ValueClassWrapper,
-        P3: ValueClassWrapper,
-        P4: ValueClassWrapper,
-        P5: ValueClassWrapper,
-        P6: ValueClassWrapper,
-        P7: ValueClassWrapper,
-        P8: ValueClassWrapper,
-        P9: ValueClassWrapper,
-        P10: ValueClassWrapper,
-        P11: ValueClassWrapper,
-        P12: ValueClassWrapper,
-        P13: ValueClassWrapper,
-        P14: ValueClassWrapper,
-        P15: ValueClassWrapper,
-        P16: ValueClassWrapper,
-        P17: ValueClassWrapper,
-        P18: ValueClassWrapper
-    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18) => T): ScalaOngoingStubbing[T] =
-      os thenAnswer f
-
-    def apply[
-        P0: ValueClassWrapper,
-        P1: ValueClassWrapper,
-        P2: ValueClassWrapper,
-        P3: ValueClassWrapper,
-        P4: ValueClassWrapper,
-        P5: ValueClassWrapper,
-        P6: ValueClassWrapper,
-        P7: ValueClassWrapper,
-        P8: ValueClassWrapper,
-        P9: ValueClassWrapper,
-        P10: ValueClassWrapper,
-        P11: ValueClassWrapper,
-        P12: ValueClassWrapper,
-        P13: ValueClassWrapper,
-        P14: ValueClassWrapper,
-        P15: ValueClassWrapper,
-        P16: ValueClassWrapper,
-        P17: ValueClassWrapper,
-        P18: ValueClassWrapper,
-        P19: ValueClassWrapper
-    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19) => T): ScalaOngoingStubbing[T] =
-      os thenAnswer f
-
-    def apply[
-        P0: ValueClassWrapper,
-        P1: ValueClassWrapper,
-        P2: ValueClassWrapper,
-        P3: ValueClassWrapper,
-        P4: ValueClassWrapper,
-        P5: ValueClassWrapper,
-        P6: ValueClassWrapper,
-        P7: ValueClassWrapper,
-        P8: ValueClassWrapper,
-        P9: ValueClassWrapper,
-        P10: ValueClassWrapper,
-        P11: ValueClassWrapper,
-        P12: ValueClassWrapper,
-        P13: ValueClassWrapper,
-        P14: ValueClassWrapper,
-        P15: ValueClassWrapper,
-        P16: ValueClassWrapper,
-        P17: ValueClassWrapper,
-        P18: ValueClassWrapper,
-        P19: ValueClassWrapper,
-        P20: ValueClassWrapper
-    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20) => T): ScalaOngoingStubbing[T] =
-      os thenAnswer f
-
-    def apply[
-        P0: ValueClassWrapper,
-        P1: ValueClassWrapper,
-        P2: ValueClassWrapper,
-        P3: ValueClassWrapper,
-        P4: ValueClassWrapper,
-        P5: ValueClassWrapper,
-        P6: ValueClassWrapper,
-        P7: ValueClassWrapper,
-        P8: ValueClassWrapper,
-        P9: ValueClassWrapper,
-        P10: ValueClassWrapper,
-        P11: ValueClassWrapper,
-        P12: ValueClassWrapper,
-        P13: ValueClassWrapper,
-        P14: ValueClassWrapper,
-        P15: ValueClassWrapper,
-        P16: ValueClassWrapper,
-        P17: ValueClassWrapper,
-        P18: ValueClassWrapper,
-        P19: ValueClassWrapper,
-        P20: ValueClassWrapper,
-        P21: ValueClassWrapper
-    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21) => T): ScalaOngoingStubbing[T] =
-      os thenAnswer f
-
-//      (2 to 22).foreach { fn =>
-//        val args = 0 until fn
-//        print(s"""
-//                 |def apply[${args.map(a => s"P$a: ValueClassWrapper").mkString(",")}](f: (${args.map(a => s"P$a").mkString(",")}) => T): ScalaOngoingStubbing[T] =
-//                 |    os thenAnswer f
-//                 |""".stripMargin)
-//      }
-  }
-
   private val ShouldAnswerOptions                                 = Set("shouldAnswer", "mustAnswer", "answers")
   private val FunctionalShouldAnswerOptions                       = ShouldAnswerOptions.map(_ + "F")
   private val FunctionalShouldAnswerOptions2                      = ShouldAnswerOptions.map(_ + "FG")
@@ -458,7 +133,7 @@ object WhenMacro {
 
     val r = c.macroApplication match {
       case q"$_.StubbingOps[$t]($invocation).$m" if ShouldAnswerOptions.contains(m.toString) =>
-        q"new _root_.org.mockito.WhenMacro.AnswerActions(_root_.org.mockito.Mockito.when[$t](${transformInvocation(c)(invocation)}))"
+        q"new _root_.org.mockito.WhenMacroRuntime.AnswerActions(_root_.org.mockito.Mockito.when[$t](${transformInvocation(c)(invocation)}))"
 
       case q"$_.$cls[..$_]($invocation).$m" if cls.toString.startsWith("StubbingOps") && FunctionalShouldAnswerOptions.contains(m.toString) =>
         q"new _root_.org.mockito.${packageName(c)(cls)}.${className(c)(cls, "IdiomaticMockito")}.AnswerActions(_root_.org.mockito.Mockito.when(${transformInvocation(c)(invocation)}))"
@@ -472,17 +147,13 @@ object WhenMacro {
     r
   }
 
-  class AnswerPFActions[T](os: ScalaFirstStubbing[T]) {
-    def apply(pf: PartialFunction[Any, T]): ScalaOngoingStubbing[T] = os thenAnswer pf
-  }
-
   private val ShouldAnswerPFOptions                                 = Set("shouldAnswerPF", "mustAnswerPF", "answersPF")
   def shouldAnswerPF[T: c.WeakTypeTag](c: blackbox.Context): c.Tree = {
     import c.universe.*
 
     val r = c.macroApplication match {
       case q"$_.StubbingOps[$t]($invocation).$m" if ShouldAnswerPFOptions.contains(m.toString) =>
-        q"new _root_.org.mockito.WhenMacro.AnswerPFActions(_root_.org.mockito.Mockito.when[$t](${transformInvocation(c)(invocation)}))"
+        q"new _root_.org.mockito.WhenMacroRuntime.AnswerPFActions(_root_.org.mockito.Mockito.when[$t](${transformInvocation(c)(invocation)}))"
 
       case o => throw new Exception(s"Couldn't recognize ${show(o)}")
     }

--- a/macro/src/main/scala/org/mockito/WhenMacroRuntime.scala
+++ b/macro/src/main/scala/org/mockito/WhenMacroRuntime.scala
@@ -1,0 +1,336 @@
+package org.mockito
+
+import org.mockito.internal.ValueClassWrapper
+import org.mockito.stubbing.{ ScalaFirstStubbing, ScalaOngoingStubbing }
+
+import scala.reflect.ClassTag
+
+/**
+ * Runtime support classes for WhenMacro. These classes are used by macro-generated code and shared across Scala 2 and Scala 3.
+ */
+object WhenMacroRuntime {
+
+  object RealMethod {
+    def willBe(called: Called.type): Called.type = called
+  }
+
+  class AnswerActions[T](os: ScalaFirstStubbing[T]) {
+    def apply(f: => T): ScalaOngoingStubbing[T] = os thenAnswer f
+
+    def apply[P0: ValueClassWrapper](f: P0 => T)(implicit classTag: ClassTag[P0] = defaultClassTag[P0]): ScalaOngoingStubbing[T] =
+      os thenAnswer f
+
+    def apply[P0: ValueClassWrapper, P1: ValueClassWrapper](f: (P0, P1) => T): ScalaOngoingStubbing[T] =
+      os thenAnswer f
+
+    def apply[P0: ValueClassWrapper, P1: ValueClassWrapper, P2: ValueClassWrapper](f: (P0, P1, P2) => T): ScalaOngoingStubbing[T] =
+      os thenAnswer f
+
+    def apply[P0: ValueClassWrapper, P1: ValueClassWrapper, P2: ValueClassWrapper, P3: ValueClassWrapper](f: (P0, P1, P2, P3) => T): ScalaOngoingStubbing[T] =
+      os thenAnswer f
+
+    def apply[P0: ValueClassWrapper, P1: ValueClassWrapper, P2: ValueClassWrapper, P3: ValueClassWrapper, P4: ValueClassWrapper](
+        f: (P0, P1, P2, P3, P4) => T
+    ): ScalaOngoingStubbing[T] =
+      os thenAnswer f
+
+    def apply[P0: ValueClassWrapper, P1: ValueClassWrapper, P2: ValueClassWrapper, P3: ValueClassWrapper, P4: ValueClassWrapper, P5: ValueClassWrapper](
+        f: (P0, P1, P2, P3, P4, P5) => T
+    ): ScalaOngoingStubbing[T] =
+      os thenAnswer f
+
+    def apply[P0: ValueClassWrapper, P1: ValueClassWrapper, P2: ValueClassWrapper, P3: ValueClassWrapper, P4: ValueClassWrapper, P5: ValueClassWrapper, P6: ValueClassWrapper](
+        f: (P0, P1, P2, P3, P4, P5, P6) => T
+    ): ScalaOngoingStubbing[T] =
+      os thenAnswer f
+
+    def apply[
+        P0: ValueClassWrapper,
+        P1: ValueClassWrapper,
+        P2: ValueClassWrapper,
+        P3: ValueClassWrapper,
+        P4: ValueClassWrapper,
+        P5: ValueClassWrapper,
+        P6: ValueClassWrapper,
+        P7: ValueClassWrapper
+    ](f: (P0, P1, P2, P3, P4, P5, P6, P7) => T): ScalaOngoingStubbing[T] =
+      os thenAnswer f
+
+    def apply[
+        P0: ValueClassWrapper,
+        P1: ValueClassWrapper,
+        P2: ValueClassWrapper,
+        P3: ValueClassWrapper,
+        P4: ValueClassWrapper,
+        P5: ValueClassWrapper,
+        P6: ValueClassWrapper,
+        P7: ValueClassWrapper,
+        P8: ValueClassWrapper
+    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8) => T): ScalaOngoingStubbing[T] =
+      os thenAnswer f
+
+    def apply[
+        P0: ValueClassWrapper,
+        P1: ValueClassWrapper,
+        P2: ValueClassWrapper,
+        P3: ValueClassWrapper,
+        P4: ValueClassWrapper,
+        P5: ValueClassWrapper,
+        P6: ValueClassWrapper,
+        P7: ValueClassWrapper,
+        P8: ValueClassWrapper,
+        P9: ValueClassWrapper
+    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9) => T): ScalaOngoingStubbing[T] =
+      os thenAnswer f
+
+    def apply[
+        P0: ValueClassWrapper,
+        P1: ValueClassWrapper,
+        P2: ValueClassWrapper,
+        P3: ValueClassWrapper,
+        P4: ValueClassWrapper,
+        P5: ValueClassWrapper,
+        P6: ValueClassWrapper,
+        P7: ValueClassWrapper,
+        P8: ValueClassWrapper,
+        P9: ValueClassWrapper,
+        P10: ValueClassWrapper
+    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) => T): ScalaOngoingStubbing[T] =
+      os thenAnswer f
+
+    def apply[
+        P0: ValueClassWrapper,
+        P1: ValueClassWrapper,
+        P2: ValueClassWrapper,
+        P3: ValueClassWrapper,
+        P4: ValueClassWrapper,
+        P5: ValueClassWrapper,
+        P6: ValueClassWrapper,
+        P7: ValueClassWrapper,
+        P8: ValueClassWrapper,
+        P9: ValueClassWrapper,
+        P10: ValueClassWrapper,
+        P11: ValueClassWrapper
+    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11) => T): ScalaOngoingStubbing[T] =
+      os thenAnswer f
+
+    def apply[
+        P0: ValueClassWrapper,
+        P1: ValueClassWrapper,
+        P2: ValueClassWrapper,
+        P3: ValueClassWrapper,
+        P4: ValueClassWrapper,
+        P5: ValueClassWrapper,
+        P6: ValueClassWrapper,
+        P7: ValueClassWrapper,
+        P8: ValueClassWrapper,
+        P9: ValueClassWrapper,
+        P10: ValueClassWrapper,
+        P11: ValueClassWrapper,
+        P12: ValueClassWrapper
+    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12) => T): ScalaOngoingStubbing[T] =
+      os thenAnswer f
+
+    def apply[
+        P0: ValueClassWrapper,
+        P1: ValueClassWrapper,
+        P2: ValueClassWrapper,
+        P3: ValueClassWrapper,
+        P4: ValueClassWrapper,
+        P5: ValueClassWrapper,
+        P6: ValueClassWrapper,
+        P7: ValueClassWrapper,
+        P8: ValueClassWrapper,
+        P9: ValueClassWrapper,
+        P10: ValueClassWrapper,
+        P11: ValueClassWrapper,
+        P12: ValueClassWrapper,
+        P13: ValueClassWrapper
+    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13) => T): ScalaOngoingStubbing[T] =
+      os thenAnswer f
+
+    def apply[
+        P0: ValueClassWrapper,
+        P1: ValueClassWrapper,
+        P2: ValueClassWrapper,
+        P3: ValueClassWrapper,
+        P4: ValueClassWrapper,
+        P5: ValueClassWrapper,
+        P6: ValueClassWrapper,
+        P7: ValueClassWrapper,
+        P8: ValueClassWrapper,
+        P9: ValueClassWrapper,
+        P10: ValueClassWrapper,
+        P11: ValueClassWrapper,
+        P12: ValueClassWrapper,
+        P13: ValueClassWrapper,
+        P14: ValueClassWrapper
+    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14) => T): ScalaOngoingStubbing[T] =
+      os thenAnswer f
+
+    def apply[
+        P0: ValueClassWrapper,
+        P1: ValueClassWrapper,
+        P2: ValueClassWrapper,
+        P3: ValueClassWrapper,
+        P4: ValueClassWrapper,
+        P5: ValueClassWrapper,
+        P6: ValueClassWrapper,
+        P7: ValueClassWrapper,
+        P8: ValueClassWrapper,
+        P9: ValueClassWrapper,
+        P10: ValueClassWrapper,
+        P11: ValueClassWrapper,
+        P12: ValueClassWrapper,
+        P13: ValueClassWrapper,
+        P14: ValueClassWrapper,
+        P15: ValueClassWrapper
+    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15) => T): ScalaOngoingStubbing[T] =
+      os thenAnswer f
+
+    def apply[
+        P0: ValueClassWrapper,
+        P1: ValueClassWrapper,
+        P2: ValueClassWrapper,
+        P3: ValueClassWrapper,
+        P4: ValueClassWrapper,
+        P5: ValueClassWrapper,
+        P6: ValueClassWrapper,
+        P7: ValueClassWrapper,
+        P8: ValueClassWrapper,
+        P9: ValueClassWrapper,
+        P10: ValueClassWrapper,
+        P11: ValueClassWrapper,
+        P12: ValueClassWrapper,
+        P13: ValueClassWrapper,
+        P14: ValueClassWrapper,
+        P15: ValueClassWrapper,
+        P16: ValueClassWrapper
+    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16) => T): ScalaOngoingStubbing[T] =
+      os thenAnswer f
+
+    def apply[
+        P0: ValueClassWrapper,
+        P1: ValueClassWrapper,
+        P2: ValueClassWrapper,
+        P3: ValueClassWrapper,
+        P4: ValueClassWrapper,
+        P5: ValueClassWrapper,
+        P6: ValueClassWrapper,
+        P7: ValueClassWrapper,
+        P8: ValueClassWrapper,
+        P9: ValueClassWrapper,
+        P10: ValueClassWrapper,
+        P11: ValueClassWrapper,
+        P12: ValueClassWrapper,
+        P13: ValueClassWrapper,
+        P14: ValueClassWrapper,
+        P15: ValueClassWrapper,
+        P16: ValueClassWrapper,
+        P17: ValueClassWrapper
+    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17) => T): ScalaOngoingStubbing[T] =
+      os thenAnswer f
+
+    def apply[
+        P0: ValueClassWrapper,
+        P1: ValueClassWrapper,
+        P2: ValueClassWrapper,
+        P3: ValueClassWrapper,
+        P4: ValueClassWrapper,
+        P5: ValueClassWrapper,
+        P6: ValueClassWrapper,
+        P7: ValueClassWrapper,
+        P8: ValueClassWrapper,
+        P9: ValueClassWrapper,
+        P10: ValueClassWrapper,
+        P11: ValueClassWrapper,
+        P12: ValueClassWrapper,
+        P13: ValueClassWrapper,
+        P14: ValueClassWrapper,
+        P15: ValueClassWrapper,
+        P16: ValueClassWrapper,
+        P17: ValueClassWrapper,
+        P18: ValueClassWrapper
+    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18) => T): ScalaOngoingStubbing[T] =
+      os thenAnswer f
+
+    def apply[
+        P0: ValueClassWrapper,
+        P1: ValueClassWrapper,
+        P2: ValueClassWrapper,
+        P3: ValueClassWrapper,
+        P4: ValueClassWrapper,
+        P5: ValueClassWrapper,
+        P6: ValueClassWrapper,
+        P7: ValueClassWrapper,
+        P8: ValueClassWrapper,
+        P9: ValueClassWrapper,
+        P10: ValueClassWrapper,
+        P11: ValueClassWrapper,
+        P12: ValueClassWrapper,
+        P13: ValueClassWrapper,
+        P14: ValueClassWrapper,
+        P15: ValueClassWrapper,
+        P16: ValueClassWrapper,
+        P17: ValueClassWrapper,
+        P18: ValueClassWrapper,
+        P19: ValueClassWrapper
+    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19) => T): ScalaOngoingStubbing[T] =
+      os thenAnswer f
+
+    def apply[
+        P0: ValueClassWrapper,
+        P1: ValueClassWrapper,
+        P2: ValueClassWrapper,
+        P3: ValueClassWrapper,
+        P4: ValueClassWrapper,
+        P5: ValueClassWrapper,
+        P6: ValueClassWrapper,
+        P7: ValueClassWrapper,
+        P8: ValueClassWrapper,
+        P9: ValueClassWrapper,
+        P10: ValueClassWrapper,
+        P11: ValueClassWrapper,
+        P12: ValueClassWrapper,
+        P13: ValueClassWrapper,
+        P14: ValueClassWrapper,
+        P15: ValueClassWrapper,
+        P16: ValueClassWrapper,
+        P17: ValueClassWrapper,
+        P18: ValueClassWrapper,
+        P19: ValueClassWrapper,
+        P20: ValueClassWrapper
+    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20) => T): ScalaOngoingStubbing[T] =
+      os thenAnswer f
+
+    def apply[
+        P0: ValueClassWrapper,
+        P1: ValueClassWrapper,
+        P2: ValueClassWrapper,
+        P3: ValueClassWrapper,
+        P4: ValueClassWrapper,
+        P5: ValueClassWrapper,
+        P6: ValueClassWrapper,
+        P7: ValueClassWrapper,
+        P8: ValueClassWrapper,
+        P9: ValueClassWrapper,
+        P10: ValueClassWrapper,
+        P11: ValueClassWrapper,
+        P12: ValueClassWrapper,
+        P13: ValueClassWrapper,
+        P14: ValueClassWrapper,
+        P15: ValueClassWrapper,
+        P16: ValueClassWrapper,
+        P17: ValueClassWrapper,
+        P18: ValueClassWrapper,
+        P19: ValueClassWrapper,
+        P20: ValueClassWrapper,
+        P21: ValueClassWrapper
+    ](f: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, P21) => T): ScalaOngoingStubbing[T] =
+      os thenAnswer f
+  }
+
+  class AnswerPFActions[T](os: ScalaFirstStubbing[T]) {
+    def apply(pf: PartialFunction[Any, T]): ScalaOngoingStubbing[T] = os thenAnswer pf
+  }
+}


### PR DESCRIPTION
Another baby step toward Scala 3

Move runtime classes out of macro-only files into shared *Runtime files, preparing for Scala 2/3 macro source split.
*Runtime classes have no macro code thus can be reused by any Scala version. WhenMacro/VerifyMacro retain all macro code, type aliases and val re-exports for backward compatibility. Quasiquotes updated to reference *Runtime types directly.