### PR TITLE
Refactor: extract macro runtime classes (Captor, DefaultValueProvider)

### DIFF
--- a/macro/src/main/scala-2/org/mockito/matchers/DefaultValueProviderMacro.scala
+++ b/macro/src/main/scala-2/org/mockito/matchers/DefaultValueProviderMacro.scala
@@ -1,0 +1,45 @@
+package org.mockito.matchers
+
+import org.mockito.internal.MacroDebug.debugResult
+
+import scala.reflect.macros.blackbox
+
+/**
+ * Scala 2 macro implementation for DefaultValueProvider.
+ */
+trait DefaultValueProviderCompat {
+  implicit def default[T]: DefaultValueProvider[T] = macro DefaultValueProviderMacro._defaultValueProvider[T]
+}
+
+object DefaultValueProviderMacro {
+  def _defaultValueProvider[T: c.WeakTypeTag](c: blackbox.Context): c.Expr[DefaultValueProvider[T]] = {
+    import c.universe.*
+    val tpe          = weakTypeOf[T]
+    val typeSymbol   = tpe.typeSymbol
+    val isValueClass = typeSymbol.isClass && typeSymbol.asClass.isDerivedValueClass
+
+    lazy val innerType =
+      tpe.members
+        .filter(_.isConstructor)
+        .flatMap(_.asMethod.paramLists)
+        .flatMap(_.map(_.typeSignature))
+        .head
+
+    val r =
+      if (isValueClass) c.Expr[DefaultValueProvider[T]] {
+        q"""
+          new _root_.org.mockito.matchers.DefaultValueProvider[$tpe] {
+            override def default: $tpe =
+              new $tpe (
+                _root_.org.mockito.matchers.DefaultValueProvider.defaultProvider[$innerType].default
+              )
+          }
+        """
+      }
+      else
+        c.Expr[DefaultValueProvider[T]](q"_root_.org.mockito.matchers.DefaultValueProvider.defaultProvider[$tpe]")
+
+    debugResult(c)("mockito-print-matcher")(r.tree)
+    r
+  }
+}

--- a/macro/src/main/scala/org/mockito/captor/Captor.scala
+++ b/macro/src/main/scala/org/mockito/captor/Captor.scala
@@ -1,59 +1,15 @@
 package org.mockito.captor
 
-import org.mockito.exceptions.base.MockitoAssertionError
-import org.mockito.exceptions.verification.{ ArgumentsAreDifferent, TooFewActualInvocations, TooManyActualInvocations }
 import org.mockito.internal.MacroDebug.debugResult
 import org.mockito.internal.ScalaVersion
 import org.mockito.internal.ScalaVersion.{ V2_12, V2_13 }
-import org.mockito.{ clazz, ArgumentCaptor }
-import org.scalactic.Equality
-import org.scalactic.TripleEquals.*
 
-import scala.jdk.CollectionConverters.*
 import scala.reflect.ClassTag
 import scala.reflect.macros.blackbox
-import scala.util.{ Failure, Try }
 
-trait Captor[T] {
-  def capture: T
+trait Captor[T] extends CaptorBase[T]
 
-  def value: T
-
-  def values: List[T]
-
-  def hasCaptured(expectations: T*)(implicit $eq: Equality[T]): Unit = {
-    val elementResult = Try {
-      expectations.zip(values).foreach { case (e, v) =>
-        if (e !== v) throw new ArgumentsAreDifferent(s"Got [$v] instead of [$e]")
-      }
-    }
-
-    val sizeResult = Try {
-      (expectations.size, values.size) match {
-        case (es, vs) if es - vs > 0 => throw new TooFewActualInvocations(s"Also expected ${es - vs} more: [${expectations.drop(vs).mkString(", ")}]")
-        case (es, vs) if es - vs < 0 => throw new TooManyActualInvocations(s"Also got ${vs - es} more: [${values.drop(es).mkString(", ")}]")
-        case _                       => None
-      }
-    }
-
-    (elementResult, sizeResult) match {
-      case (Failure(ef), Failure(sf: MockitoAssertionError)) => throw new MockitoAssertionError(sf, ef.getMessage)
-      case (_, Failure(sf))                                  => throw sf
-      case (Failure(ef), _)                                  => throw ef
-      case _                                                 =>
-    }
-  }
-}
-
-class WrapperCaptor[T: ClassTag] extends Captor[T] {
-  private val argumentCaptor: ArgumentCaptor[T] = ArgumentCaptor.forClass(clazz)
-
-  override def capture: T = argumentCaptor.capture()
-
-  override def value: T = argumentCaptor.getValue
-
-  override def values: List[T] = argumentCaptor.getAllValues.asScala.toList
-}
+class WrapperCaptor[T: ClassTag] extends WrapperCaptorBase[T] with Captor[T]
 
 object Captor {
   implicit def asCapture[T](c: Captor[T]): T = c.capture

--- a/macro/src/main/scala/org/mockito/captor/CaptorBase.scala
+++ b/macro/src/main/scala/org/mockito/captor/CaptorBase.scala
@@ -1,0 +1,58 @@
+package org.mockito.captor
+
+import org.mockito.exceptions.base.MockitoAssertionError
+import org.mockito.exceptions.verification.{ ArgumentsAreDifferent, TooFewActualInvocations, TooManyActualInvocations }
+import org.mockito.{ clazz, ArgumentCaptor }
+import org.scalactic.Equality
+import org.scalactic.TripleEquals.*
+
+import scala.jdk.CollectionConverters.*
+import scala.reflect.ClassTag
+import scala.util.{ Failure, Try }
+
+/**
+ * Base trait for argument capturing with shared runtime logic. Shared across Scala 2 and Scala 3.
+ */
+trait CaptorBase[T] {
+  def capture: T
+
+  def value: T
+
+  def values: List[T]
+
+  def hasCaptured(expectations: T*)(implicit $eq: Equality[T]): Unit = {
+    val elementResult = Try {
+      expectations.zip(values).foreach { case (e, v) =>
+        if (e !== v) throw new ArgumentsAreDifferent(s"Got [$v] instead of [$e]")
+      }
+    }
+
+    val sizeResult = Try {
+      (expectations.size, values.size) match {
+        case (es, vs) if es - vs > 0 => throw new TooFewActualInvocations(s"Also expected ${es - vs} more: [${expectations.drop(vs).mkString(", ")}]")
+        case (es, vs) if es - vs < 0 => throw new TooManyActualInvocations(s"Also got ${vs - es} more: [${values.drop(es).mkString(", ")}]")
+        case _                       => None
+      }
+    }
+
+    (elementResult, sizeResult) match {
+      case (Failure(ef), Failure(sf: MockitoAssertionError)) => throw new MockitoAssertionError(sf, ef.getMessage)
+      case (_, Failure(sf))                                  => throw sf
+      case (Failure(ef), _)                                  => throw ef
+      case _                                                 =>
+    }
+  }
+}
+
+/**
+ * Default captor implementation wrapping Mockito's ArgumentCaptor. Shared across Scala 2 and Scala 3.
+ */
+abstract class WrapperCaptorBase[T: ClassTag] extends CaptorBase[T] {
+  private val argumentCaptor: ArgumentCaptor[T] = ArgumentCaptor.forClass(clazz)
+
+  override def capture: T = argumentCaptor.capture()
+
+  override def value: T = argumentCaptor.getValue
+
+  override def values: List[T] = argumentCaptor.getAllValues.asScala.toList
+}

--- a/macro/src/main/scala/org/mockito/matchers/DefaultValueProvider.scala
+++ b/macro/src/main/scala/org/mockito/matchers/DefaultValueProvider.scala
@@ -1,49 +1,15 @@
 package org.mockito.matchers
 
-import org.mockito.internal.MacroDebug.debugResult
-
-import scala.reflect.macros.blackbox
-
+/**
+ * Runtime support for providing default values. Shared across Scala 2 and Scala 3.
+ */
 trait DefaultValueProvider[T] {
   def default: T
 }
 
-object DefaultValueProvider {
+object DefaultValueProvider extends DefaultValueProviderCompat {
   def defaultProvider[T]: DefaultValueProvider[T] =
     new DefaultValueProvider[T] {
       override def default: T = null.asInstanceOf[T]
     }
-
-  implicit def default[T]: DefaultValueProvider[T] = macro _defaultValueProvider[T]
-
-  def _defaultValueProvider[T: c.WeakTypeTag](c: blackbox.Context): c.Expr[DefaultValueProvider[T]] = {
-    import c.universe.*
-    val tpe          = weakTypeOf[T]
-    val typeSymbol   = tpe.typeSymbol
-    val isValueClass = typeSymbol.isClass && typeSymbol.asClass.isDerivedValueClass
-
-    lazy val innerType =
-      tpe.members
-        .filter(_.isConstructor)
-        .flatMap(_.asMethod.paramLists)
-        .flatMap(_.map(_.typeSignature))
-        .head
-
-    val r =
-      if (isValueClass) c.Expr[DefaultValueProvider[T]] {
-        q"""
-          new _root_.org.mockito.matchers.DefaultValueProvider[$tpe] {
-            override def default: $tpe =
-              new $tpe (
-                _root_.org.mockito.matchers.DefaultValueProvider.defaultProvider[$innerType].default
-              )
-          }
-        """
-      }
-      else
-        c.Expr[DefaultValueProvider[T]](q"_root_.org.mockito.matchers.DefaultValueProvider.defaultProvider[$tpe]")
-
-    debugResult(c)("mockito-print-matcher")(r.tree)
-    r
-  }
 }


### PR DESCRIPTION
Another step toward Scala 3.
Extracts shared runtime code from more macro-dependent files:

- `CaptorBase[T]` and `WrapperCaptorBase[T]`: shared Scala-version agnostic code
- `Captor[T]` now extends `CaptorBase[T]`, `WrapperCaptor` extends both
- `DefaultValueProvider`: runtime trait+object kept in shared scala/
- `DefaultValueProviderMacro`: macro code extracted from `DefaultValueProvider`