### PR TITLE
Refactor: extract core runtime traits to shared files in core module

### DIFF
--- a/core/src/main/scala/org/mockito/IdiomaticMockitoBase.scala
+++ b/core/src/main/scala/org/mockito/IdiomaticMockitoBase.scala
@@ -1,102 +1,17 @@
 package org.mockito
 
-import org.mockito.stubbing.{ ScalaFirstStubbing, ScalaOngoingStubbing }
-import org.mockito.verification.VerificationMode
+object IdiomaticMockitoBase extends IdiomaticMockitoBaseRuntime {
 
-import scala.concurrent.duration.Duration
-
-object IdiomaticMockitoBase {
-  object Returned
   case class ReturnedBy[T]() {
     def by[S](stubbing: S)(implicit $ev: T <:< S): S = macro DoSomethingMacro.returnedBy[T, S]
   }
 
-  object Answered
   case class AnsweredBy[T]() {
     def by[S](stubbing: S)(implicit $ev: T <:< S): S = macro DoSomethingMacro.answeredBy[T, S]
   }
 
-  object Thrown
   class ThrownBy[E] {
     def by[T](stubbing: T)(implicit $ev: E <:< Throwable): T = macro DoSomethingMacro.thrownBy[T]
-  }
-
-  object On
-  object Never
-  sealed trait CalledAgain
-  object IgnoringStubs
-  case object CalledAgain extends CalledAgain {
-    def apply(i: IgnoringStubs.type): CalledAgain = LenientCalledAgain
-  }
-  case object LenientCalledAgain extends CalledAgain
-
-  case class Times(times: Int) extends ScalaVerificationMode {
-    override def verificationMode: VerificationMode = Mockito.times(times)
-    def within(d: Duration): ScalaVerificationMode  =
-      new ScalaVerificationMode {
-        override def verificationMode: VerificationMode = Mockito.timeout(d.toMillis).times(times)
-      }
-    def after(d: Duration): ScalaVerificationMode =
-      new ScalaVerificationMode {
-        override def verificationMode: VerificationMode = Mockito.after(d.toMillis).times(times)
-      }
-  }
-
-  // Helper methods for the specs2 macro
-  def Exactly(times: Int): Times = Times(times)
-  def AtLeastOne: AtLeast        = AtLeast(1)
-  def AtLeastTwo: AtLeast        = AtLeast(2)
-  def AtLeastThree: AtLeast      = AtLeast(3)
-  def AtMostOne: AtMost          = AtMost(1)
-  def AtMostTwo: AtMost          = AtMost(2)
-  def AtMostThree: AtMost        = AtMost(3)
-
-  case class AtLeast(times: Int) extends ScalaVerificationMode {
-    override def verificationMode: VerificationMode = Mockito.atLeast(times)
-    def within(d: Duration): ScalaVerificationMode  =
-      new ScalaVerificationMode {
-        override def verificationMode: VerificationMode = Mockito.timeout(d.toMillis).atLeast(times)
-      }
-    def after(d: Duration): ScalaVerificationMode =
-      new ScalaVerificationMode {
-        override def verificationMode: VerificationMode = Mockito.after(d.toMillis).atLeast(times)
-      }
-  }
-
-  case class AtMost(times: Int) extends ScalaVerificationMode {
-    override def verificationMode: VerificationMode = Mockito.atMost(times)
-    def after(d: Duration): ScalaVerificationMode   =
-      new ScalaVerificationMode {
-        override def verificationMode: VerificationMode = Mockito.after(d.toMillis).atMost(times)
-      }
-  }
-
-  object OnlyOn extends ScalaVerificationMode {
-    override def verificationMode: VerificationMode = Mockito.only
-    def within(d: Duration): ScalaVerificationMode  =
-      new ScalaVerificationMode {
-        override def verificationMode: VerificationMode = Mockito.timeout(d.toMillis).only
-      }
-    def after(d: Duration): ScalaVerificationMode =
-      new ScalaVerificationMode {
-        override def verificationMode: VerificationMode = Mockito.after(d.toMillis).only
-      }
-  }
-
-  class ReturnActions[T](os: ScalaFirstStubbing[T]) {
-    def apply(value: T, values: T*): ScalaOngoingStubbing[T] = os.thenReturn(value, values*)
-  }
-
-  class ThrowActions[T](os: ScalaFirstStubbing[T]) {
-    def apply[E <: Throwable](e: E*): ScalaOngoingStubbing[T] = os thenThrow (e*)
-  }
-
-  // types for postfix verifications
-  object CallWord
-  object CallsWord {
-    // No special logic here - the pattern "calls(ignoringStubs)" is detected by Expect macro
-    // and transformed into the right Mockito call
-    def apply(ignoringStubsWord: IgnoringStubs.type): CallsWord.type = this
   }
 }
 

--- a/core/src/main/scala/org/mockito/IdiomaticMockitoBaseRuntime.scala
+++ b/core/src/main/scala/org/mockito/IdiomaticMockitoBaseRuntime.scala
@@ -1,0 +1,128 @@
+package org.mockito
+
+import org.mockito.stubbing.{ ScalaFirstStubbing, ScalaOngoingStubbing }
+import org.mockito.verification.VerificationMode
+
+import scala.concurrent.duration.Duration
+
+/**
+ * Runtime support for IdiomaticMockitoBase. Shared across Scala 2 and Scala 3. Macro-based operations are in version-specific IdiomaticMockitoBase. This trait can be extended by
+ * objects that need to provide these runtime members (like the scala-2 IdiomaticMockitoBase object).
+ */
+trait IdiomaticMockitoBaseRuntime {
+  // Re-export singleton objects from companion object
+  val Returned: IdiomaticMockitoBaseRuntime.Returned.type = IdiomaticMockitoBaseRuntime.Returned
+  val Answered: IdiomaticMockitoBaseRuntime.Answered.type = IdiomaticMockitoBaseRuntime.Answered
+  val Thrown: IdiomaticMockitoBaseRuntime.Thrown.type     = IdiomaticMockitoBaseRuntime.Thrown
+  val On: IdiomaticMockitoBaseRuntime.On.type             = IdiomaticMockitoBaseRuntime.On
+  val Never: IdiomaticMockitoBaseRuntime.Never.type       = IdiomaticMockitoBaseRuntime.Never
+  type CalledAgain = IdiomaticMockitoBaseRuntime.CalledAgain
+  val CalledAgain: IdiomaticMockitoBaseRuntime.CalledAgain.type               = IdiomaticMockitoBaseRuntime.CalledAgain
+  val LenientCalledAgain: IdiomaticMockitoBaseRuntime.LenientCalledAgain.type = IdiomaticMockitoBaseRuntime.LenientCalledAgain
+  val IgnoringStubs: IdiomaticMockitoBaseRuntime.IgnoringStubs.type           = IdiomaticMockitoBaseRuntime.IgnoringStubs
+  type Times = IdiomaticMockitoBaseRuntime.Times
+  val Times: IdiomaticMockitoBaseRuntime.Times.type = IdiomaticMockitoBaseRuntime.Times
+  type AtLeast = IdiomaticMockitoBaseRuntime.AtLeast
+  val AtLeast: IdiomaticMockitoBaseRuntime.AtLeast.type = IdiomaticMockitoBaseRuntime.AtLeast
+  type AtMost = IdiomaticMockitoBaseRuntime.AtMost
+  val AtMost: IdiomaticMockitoBaseRuntime.AtMost.type = IdiomaticMockitoBaseRuntime.AtMost
+  val OnlyOn: IdiomaticMockitoBaseRuntime.OnlyOn.type = IdiomaticMockitoBaseRuntime.OnlyOn
+  type ReturnActions[T] = IdiomaticMockitoBaseRuntime.ReturnActions[T]
+  type ThrowActions[T]  = IdiomaticMockitoBaseRuntime.ThrowActions[T]
+  val CallWord: IdiomaticMockitoBaseRuntime.CallWord.type   = IdiomaticMockitoBaseRuntime.CallWord
+  val CallsWord: IdiomaticMockitoBaseRuntime.CallsWord.type = IdiomaticMockitoBaseRuntime.CallsWord
+  def Exactly(times: Int): Times                            = IdiomaticMockitoBaseRuntime.Exactly(times)
+  val AtLeastOne: AtLeast                                   = IdiomaticMockitoBaseRuntime.AtLeastOne
+  val AtLeastTwo: AtLeast                                   = IdiomaticMockitoBaseRuntime.AtLeastTwo
+  val AtLeastThree: AtLeast                                 = IdiomaticMockitoBaseRuntime.AtLeastThree
+  val AtMostOne: AtMost                                     = IdiomaticMockitoBaseRuntime.AtMostOne
+  val AtMostTwo: AtMost                                     = IdiomaticMockitoBaseRuntime.AtMostTwo
+  val AtMostThree: AtMost                                   = IdiomaticMockitoBaseRuntime.AtMostThree
+}
+
+/**
+ * Companion object containing the actual singleton runtime objects and classes.
+ */
+object IdiomaticMockitoBaseRuntime {
+  object Returned
+  object Answered
+  object Thrown
+
+  object On
+  object Never
+  sealed trait CalledAgain
+  object IgnoringStubs
+  case object CalledAgain extends CalledAgain {
+    def apply(i: IgnoringStubs.type): CalledAgain = LenientCalledAgain
+  }
+  case object LenientCalledAgain extends CalledAgain
+
+  case class Times(times: Int) extends ScalaVerificationMode {
+    override def verificationMode: VerificationMode = Mockito.times(times)
+    def within(d: Duration): ScalaVerificationMode  =
+      new ScalaVerificationMode {
+        override def verificationMode: VerificationMode = Mockito.timeout(d.toMillis).times(times)
+      }
+    def after(d: Duration): ScalaVerificationMode =
+      new ScalaVerificationMode {
+        override def verificationMode: VerificationMode = Mockito.after(d.toMillis).times(times)
+      }
+  }
+
+  // Helper methods for the specs2 macro
+  def Exactly(times: Int): Times = Times(times)
+  def AtLeastOne: AtLeast        = AtLeast(1)
+  def AtLeastTwo: AtLeast        = AtLeast(2)
+  def AtLeastThree: AtLeast      = AtLeast(3)
+  def AtMostOne: AtMost          = AtMost(1)
+  def AtMostTwo: AtMost          = AtMost(2)
+  def AtMostThree: AtMost        = AtMost(3)
+
+  case class AtLeast(times: Int) extends ScalaVerificationMode {
+    override def verificationMode: VerificationMode = Mockito.atLeast(times)
+    def within(d: Duration): ScalaVerificationMode  =
+      new ScalaVerificationMode {
+        override def verificationMode: VerificationMode = Mockito.timeout(d.toMillis).atLeast(times)
+      }
+    def after(d: Duration): ScalaVerificationMode =
+      new ScalaVerificationMode {
+        override def verificationMode: VerificationMode = Mockito.after(d.toMillis).atLeast(times)
+      }
+  }
+
+  case class AtMost(times: Int) extends ScalaVerificationMode {
+    override def verificationMode: VerificationMode = Mockito.atMost(times)
+    def after(d: Duration): ScalaVerificationMode   =
+      new ScalaVerificationMode {
+        override def verificationMode: VerificationMode = Mockito.after(d.toMillis).atMost(times)
+      }
+  }
+
+  object OnlyOn extends ScalaVerificationMode {
+    override def verificationMode: VerificationMode = Mockito.only
+    def within(d: Duration): ScalaVerificationMode  =
+      new ScalaVerificationMode {
+        override def verificationMode: VerificationMode = Mockito.timeout(d.toMillis).only
+      }
+    def after(d: Duration): ScalaVerificationMode =
+      new ScalaVerificationMode {
+        override def verificationMode: VerificationMode = Mockito.after(d.toMillis).only
+      }
+  }
+
+  class ReturnActions[T](os: ScalaFirstStubbing[T]) {
+    def apply(value: T, values: T*): ScalaOngoingStubbing[T] = os.thenReturn(value, values*)
+  }
+
+  class ThrowActions[T](os: ScalaFirstStubbing[T]) {
+    def apply[E <: Throwable](e: E*): ScalaOngoingStubbing[T] = os thenThrow (e*)
+  }
+
+  // types for postfix verifications
+  object CallWord
+  object CallsWord {
+    // No special logic here - the pattern "calls(ignoringStubs)" is detected by Expect macro
+    // and transformed into the right Mockito call
+    def apply(ignoringStubsWord: IgnoringStubs.type): CallsWord.type = this
+  }
+}

--- a/core/src/main/scala/org/mockito/IdiomaticStubbing.scala
+++ b/core/src/main/scala/org/mockito/IdiomaticStubbing.scala
@@ -3,8 +3,10 @@ package org.mockito
 import org.mockito.WhenMacro.*
 import org.mockito.stubbing.ScalaOngoingStubbing
 
-trait IdiomaticStubbing extends MockitoEnhancer with ScalacticSerialisableHack {
+trait IdiomaticStubbing extends IdiomaticStubbingRuntime {
   import org.mockito.IdiomaticMockitoBase.*
+
+  val called: Called.type = Called
 
   implicit class StubbingOps[T](stubbing: T) {
     def shouldReturn: ReturnActions[T] = macro WhenMacro.shouldReturn[T]
@@ -34,14 +36,6 @@ trait IdiomaticStubbing extends MockitoEnhancer with ScalacticSerialisableHack {
     def mustDoNothing(): Unit = macro DoSomethingMacro.doesNothing
     def doesNothing(): Unit = macro DoSomethingMacro.doesNothing
   }
-
-  val called: Called.type            = Called
-  val thrown: Thrown.type            = Thrown
-  val returned: Returned.type        = Returned
-  val answered: Answered.type        = Answered
-  val theRealMethod: RealMethod.type = RealMethod
-
-  val realMethod: RealMethod.type = RealMethod
 
   implicit class DoSomethingOps[R](v: R) {
     def willBe(r: Returned.type): ReturnedBy[R] = ReturnedBy[R]()

--- a/core/src/main/scala/org/mockito/IdiomaticStubbingRuntime.scala
+++ b/core/src/main/scala/org/mockito/IdiomaticStubbingRuntime.scala
@@ -1,0 +1,17 @@
+package org.mockito
+
+import org.mockito.WhenMacroRuntime.RealMethod
+
+/**
+ * Runtime support for IdiomaticStubbing. Shared across Scala 2 and Scala 3. Macro-based stubbing operations are in version-specific IdiomaticStubbing.
+ */
+trait IdiomaticStubbingRuntime extends MockitoEnhancer with ScalacticSerialisableHack {
+  import org.mockito.IdiomaticMockitoBaseRuntime.*
+
+  val thrown: Thrown.type            = Thrown
+  val returned: Returned.type        = Returned
+  val answered: Answered.type        = Answered
+  val theRealMethod: RealMethod.type = RealMethod
+
+  val realMethod: RealMethod.type = RealMethod
+}

--- a/core/src/main/scala/org/mockito/IdiomaticVerifications.scala
+++ b/core/src/main/scala/org/mockito/IdiomaticVerifications.scala
@@ -1,0 +1,9 @@
+package org.mockito
+
+trait IdiomaticVerifications {
+
+  type Verification
+
+  def verification(v: => Any): Verification
+
+}

--- a/core/src/main/scala/org/mockito/PostfixVerifications.scala
+++ b/core/src/main/scala/org/mockito/PostfixVerifications.scala
@@ -1,14 +1,6 @@
 package org.mockito
 
-trait IdiomaticVerifications {
-
-  type Verification
-
-  def verification(v: => Any): Verification
-
-}
-
-trait PostfixVerifications extends IdiomaticVerifications {
+trait PostfixVerifications extends PostfixVerificationsRuntime {
 
   import org.mockito.IdiomaticMockitoBase.*
 
@@ -23,52 +15,6 @@ trait PostfixVerifications extends IdiomaticVerifications {
     def wasCalled(called: ScalaVerificationMode)(implicit order: VerifyOrder): Verification = macro VerifyMacro.wasMacro[T, Verification]
   }
 
-  val calledAgain: CalledAgain.type     = CalledAgain
-  val ignoringStubs: IgnoringStubs.type = IgnoringStubs
-
-  val on: On.type                = On
-  val onlyHere: OnlyOn.type      = OnlyOn
-  val once: Times                = Times(1)
-  val twice: Times               = Times(2)
-  val thrice: Times              = Times(3)
-  val threeTimes: Times          = Times(3)
-  val fourTimes: Times           = Times(4)
-  val fiveTimes: Times           = Times(5)
-  val sixTimes: Times            = Times(6)
-  val sevenTimes: Times          = Times(7)
-  val eightTimes: Times          = Times(8)
-  val nineTimes: Times           = Times(9)
-  val tenTimes: Times            = Times(10)
-  val atLeastOnce: AtLeast       = AtLeast(1)
-  val atLeastTwice: AtLeast      = AtLeast(2)
-  val atLeastThrice: AtLeast     = AtLeast(3)
-  val atLeastThreeTimes: AtLeast = AtLeast(3)
-  val atLeastFourTimes: AtLeast  = AtLeast(4)
-  val atLeastFiveTimes: AtLeast  = AtLeast(5)
-  val atLeastSixTimes: AtLeast   = AtLeast(6)
-  val atLeastSevenTimes: AtLeast = AtLeast(7)
-  val atLeastEightTimes: AtLeast = AtLeast(8)
-  val atLeastNineTimes: AtLeast  = AtLeast(9)
-  val atLeastTenTimes: AtLeast   = AtLeast(10)
-  val atMostOnce: AtMost         = AtMost(1)
-  val atMostTwice: AtMost        = AtMost(2)
-  val atMostThrice: AtMost       = AtMost(3)
-  val atMostThreeTimes: AtMost   = AtMost(3)
-  val atMostFourTimes: AtMost    = AtMost(4)
-  val atMostFiveTimes: AtMost    = AtMost(5)
-  val atMostSixTimes: AtMost     = AtMost(6)
-  val atMostSevenTimes: AtMost   = AtMost(7)
-  val atMostEightTimes: AtMost   = AtMost(8)
-  val atMostNineTimes: AtMost    = AtMost(9)
-  val atMostTenTimes: AtMost     = AtMost(10)
-
   def InOrder(mocks: AnyRef*)(verifications: VerifyInOrder => Verification): Verification = verifications(VerifyInOrder(mocks))
-
-  def atLeast(t: Times): AtLeast = AtLeast(t.times)
-  def atMost(t: Times): AtMost   = AtMost(t.times)
-
-  implicit class VerificationsIntOps(i: Int) {
-    def times: Times = Times(i)
-  }
 
 }

--- a/core/src/main/scala/org/mockito/PostfixVerificationsRuntime.scala
+++ b/core/src/main/scala/org/mockito/PostfixVerificationsRuntime.scala
@@ -1,0 +1,56 @@
+package org.mockito
+
+/**
+ * Runtime support for PostfixVerifications. Shared across Scala 2 and Scala 3. Macro-based verification operations are in version-specific PostfixVerifications.
+ */
+trait PostfixVerificationsRuntime extends IdiomaticVerifications {
+
+  import org.mockito.IdiomaticMockitoBaseRuntime.*
+
+  val calledAgain: CalledAgain.type     = CalledAgain
+  val ignoringStubs: IgnoringStubs.type = IgnoringStubs
+
+  val on: On.type                = On
+  val onlyHere: OnlyOn.type      = OnlyOn
+  val once: Times                = Times(1)
+  val twice: Times               = Times(2)
+  val thrice: Times              = Times(3)
+  val threeTimes: Times          = Times(3)
+  val fourTimes: Times           = Times(4)
+  val fiveTimes: Times           = Times(5)
+  val sixTimes: Times            = Times(6)
+  val sevenTimes: Times          = Times(7)
+  val eightTimes: Times          = Times(8)
+  val nineTimes: Times           = Times(9)
+  val tenTimes: Times            = Times(10)
+  val atLeastOnce: AtLeast       = AtLeast(1)
+  val atLeastTwice: AtLeast      = AtLeast(2)
+  val atLeastThrice: AtLeast     = AtLeast(3)
+  val atLeastThreeTimes: AtLeast = AtLeast(3)
+  val atLeastFourTimes: AtLeast  = AtLeast(4)
+  val atLeastFiveTimes: AtLeast  = AtLeast(5)
+  val atLeastSixTimes: AtLeast   = AtLeast(6)
+  val atLeastSevenTimes: AtLeast = AtLeast(7)
+  val atLeastEightTimes: AtLeast = AtLeast(8)
+  val atLeastNineTimes: AtLeast  = AtLeast(9)
+  val atLeastTenTimes: AtLeast   = AtLeast(10)
+  val atMostOnce: AtMost         = AtMost(1)
+  val atMostTwice: AtMost        = AtMost(2)
+  val atMostThrice: AtMost       = AtMost(3)
+  val atMostThreeTimes: AtMost   = AtMost(3)
+  val atMostFourTimes: AtMost    = AtMost(4)
+  val atMostFiveTimes: AtMost    = AtMost(5)
+  val atMostSixTimes: AtMost     = AtMost(6)
+  val atMostSevenTimes: AtMost   = AtMost(7)
+  val atMostEightTimes: AtMost   = AtMost(8)
+  val atMostNineTimes: AtMost    = AtMost(9)
+  val atMostTenTimes: AtMost     = AtMost(10)
+
+  def atLeast(t: Times): AtLeast = AtLeast(t.times)
+  def atMost(t: Times): AtMost   = AtMost(t.times)
+
+  implicit class VerificationsIntOps(i: Int) {
+    def times: Times = Times(i)
+  }
+
+}

--- a/core/src/main/scala/org/mockito/PrefixExpectations.scala
+++ b/core/src/main/scala/org/mockito/PrefixExpectations.scala
@@ -1,15 +1,8 @@
 package org.mockito
 
-trait PrefixExpectations extends IdiomaticVerifications {
+trait PrefixExpectations extends PrefixExpectationsRuntime {
 
   import org.mockito.IdiomaticMockitoBase.*
-
-  type Calls = Times
-
-  val call: CallWord.type   = CallWord
-  val calls: CallsWord.type = CallsWord
-
-  val ignoringStubs: IgnoringStubs.type = IgnoringStubs
 
   object expect {
     def a(callWord: CallWord.type): ExpectationOps       = new ExpectationOps(Times(1))
@@ -82,9 +75,4 @@ trait PrefixExpectations extends IdiomaticVerifications {
   }
 
   def InOrder(mocks: AnyRef*)(verifications: VerifyInOrder => Verification): Verification = verifications(VerifyInOrder(mocks))
-
-  implicit class IntOps(i: Int) {
-    def calls: Calls = Times(i)
-    def call: Calls  = Times(i)
-  }
 }

--- a/core/src/main/scala/org/mockito/PrefixExpectationsRuntime.scala
+++ b/core/src/main/scala/org/mockito/PrefixExpectationsRuntime.scala
@@ -1,0 +1,21 @@
+package org.mockito
+
+/**
+ * Runtime support for PrefixExpectations. Shared across Scala 2 and Scala 3. Macro-based expectation operations are in version-specific PrefixExpectations.
+ */
+trait PrefixExpectationsRuntime extends IdiomaticVerifications {
+
+  import org.mockito.IdiomaticMockitoBaseRuntime.*
+
+  type Calls = Times
+
+  val call: CallWord.type   = CallWord
+  val calls: CallsWord.type = CallsWord
+
+  val ignoringStubs: IgnoringStubs.type = IgnoringStubs
+
+  implicit class IntOps(i: Int) {
+    def calls: Calls = Times(i)
+    def call: Calls  = Times(i)
+  }
+}


### PR DESCRIPTION
And another split to macro and macro-free/runtime code, this time in core module.
Original files now extend their Runtime counterparts, keeping only macro-dependent code (implicit classes with macro methods).
Re-exports of vals and objects in *Runtime traits are necessary to keep stable references and backward compatibility.
