### PR TITLE
Rename case class Raised/RaisedG to RaisedBy/RaisedByG in cats and scalaz

### DIFF
--- a/cats/src/main/scala/org/mockito/cats/IdiomaticMockitoCats.scala
+++ b/cats/src/main/scala/org/mockito/cats/IdiomaticMockitoCats.scala
@@ -49,8 +49,8 @@ trait IdiomaticMockitoCats extends ScalacticSerialisableHack {
   implicit class DoSomethingOpsCats[R](v: R) {
     def willBe(r: ReturnedF.type): ReturnedByF[R]   = ReturnedByF[R]()
     def willBe(r: ReturnedFG.type): ReturnedByFG[R] = ReturnedByFG[R]()
-    def willBe(r: Raised.type): Raised[R]           = Raised[R]()
-    def willBe(r: RaisedG.type): RaisedG[R]         = RaisedG[R]()
+    def willBe(r: Raised.type): RaisedBy[R]         = RaisedBy[R]()
+    def willBe(r: RaisedG.type): RaisedByG[R]       = RaisedByG[R]()
     def willBe(r: AnsweredF.type): AnsweredByF[R]   = AnsweredByF[R]()
     def willBe(r: AnsweredFG.type): AnsweredByFG[R] = AnsweredByFG[R]()
   }
@@ -127,12 +127,12 @@ object IdiomaticMockitoCats extends IdiomaticMockitoCats {
   }
 
   object Raised
-  case class Raised[T]() {
+  case class RaisedBy[T]() {
     def by[F[_], E](stubbing: F[E])(implicit F: ApplicativeError[F, ? >: T]): F[E] = macro DoSomethingMacro.raised[E]
   }
 
   object RaisedG
-  case class RaisedG[T]() {
+  case class RaisedByG[T]() {
     def by[F[_], G[_], E](stubbing: F[G[E]])(implicit F: Applicative[F], G: ApplicativeError[G, ? >: T]): F[G[E]] =
       macro DoSomethingMacro.raisedG[E]
   }

--- a/scalaz/src/main/scala/org/mockito/scalaz/IdiomaticMockitoScalaz.scala
+++ b/scalaz/src/main/scala/org/mockito/scalaz/IdiomaticMockitoScalaz.scala
@@ -49,8 +49,8 @@ trait IdiomaticMockitoScalaz extends ScalacticSerialisableHack {
   implicit class DoSomethingOpsScalaz[R](v: R) {
     def willBe(r: ReturnedF.type): ReturnedByF[R]   = ReturnedByF[R]()
     def willBe(r: ReturnedFG.type): ReturnedByFG[R] = ReturnedByFG[R]()
-    def willBe(r: Raised.type): Raised[R]           = Raised[R]()
-    def willBe(r: RaisedG.type): RaisedG[R]         = RaisedG[R]()
+    def willBe(r: Raised.type): RaisedBy[R]         = RaisedBy[R]()
+    def willBe(r: RaisedG.type): RaisedByG[R]       = RaisedByG[R]()
     def willBe(r: AnsweredF.type): AnsweredByF[R]   = AnsweredByF[R]()
     def willBe(r: AnsweredFG.type): AnsweredByFG[R] = AnsweredByFG[R]()
   }
@@ -127,12 +127,12 @@ object IdiomaticMockitoScalaz extends IdiomaticMockitoScalaz {
   }
 
   object Raised
-  case class Raised[T]() {
+  case class RaisedBy[T]() {
     def by[F[_], E](stubbing: F[E])(implicit F: MonadError[F, ? >: T]): F[E] = macro DoSomethingMacro.raised[E]
   }
 
   object RaisedG
-  case class RaisedG[T]() {
+  case class RaisedByG[T]() {
     def by[F[_], G[_], E](stubbing: F[G[E]])(implicit F: Applicative[F], G: MonadError[G, ? >: T]): F[G[E]] =
       macro DoSomethingMacro.raisedG[E]
   }


### PR DESCRIPTION
Aligns naming with the existing By-suffix pattern used for all other action case classes (`ReturnedByF`, `AnsweredByF`, `ReturnedByFG`, etc.).

Previously `Raised`/`RaisedG` were both the DSL sentinel object name and the action case class name, which is not a problem per se. However it creates an ambiguity during the upcoming runtime-extraction split where the sentinel objects move to a shared Runtime file while the case classes with macro `.by` methods stay in the scala-2 source tree.

While it's not backward compatible ( i guess we can also bump version to 2.1.0 to signify that), i don't expect user-visible changes, as users most likely not use the types as it's a dsl. Tests in this project illustrate it nicely:

```scala
Error("boom") willBe raisedG by aMock.returnsFutureEither("bye")
```
```scala
(new RuntimeException("Boom"): Throwable) willBe raised by aMock.returnsFuture("bye")
```
