### PR TITLE
Refactor: extract specs2 macro methods to scala-2

### DIFF
--- a/specs2/src/main/scala-2/org/mockito/specs2/MockitoCompat.scala
+++ b/specs2/src/main/scala-2/org/mockito/specs2/MockitoCompat.scala
@@ -1,0 +1,24 @@
+package org.mockito.specs2
+
+import org.mockito.{ Specs2VerifyMacro, VerifyOrder }
+import org.specs2.matcher.MatchResult
+
+/**
+ * Scala 2 compatibility layer for Mockito specs2 integration. Provides macro-based verification methods.
+ */
+private[specs2] trait MockitoCompat extends MockitoSpecs2Support {
+
+  /**
+   * class supporting 'was' and 'were' methods to forward mockito calls to the CallsMatcher matcher
+   */
+  class Calls {
+    def were[T](calls: => T)(implicit order: VerifyOrder): Verification = macro Specs2VerifyMacro.wasMacro[T, Verification]
+    def was[T](calls: T)(implicit order: VerifyOrder): Verification = macro Specs2VerifyMacro.wasMacro[T, Verification]
+  }
+
+  implicit class MatchResultOps[T](m: MatchResult[T]) {
+    def andThen[O](calls: => O)(implicit order: VerifyOrder): Verification = macro Specs2VerifyMacro.wasMacro[O, Verification]
+  }
+
+  def got[T](calls: => T)(implicit order: VerifyOrder): Verification = macro Specs2VerifyMacro.wasMacro[T, Verification]
+}

--- a/specs2/src/main/scala/org/mockito/specs2/Mockito.scala
+++ b/specs2/src/main/scala/org/mockito/specs2/Mockito.scala
@@ -5,15 +5,15 @@ import org.mockito.hamcrest.MockitoHamcrest
 import org.mockito.internal.ValueClassExtractor
 import org.mockito.matchers.DefaultMatcher
 import org.mockito.stubbing.ScalaOngoingStubbing
-import org.mockito.{ ArgumentMatchersSugar, IdiomaticStubbing, PostfixVerifications, Specs2VerifyMacro, VerifyInOrder, VerifyOrder }
+import org.mockito.{ ArgumentMatchersSugar, IdiomaticStubbing, PostfixVerifications, VerifyInOrder }
 import org.scalactic.{ Equality, Prettifier }
 import org.specs2.control.Exceptions.catchAll
 import org.specs2.control.Throwablex.*
-import org.specs2.matcher.{ Expectable, MatchFailure, MatchResult, MatchSuccess, Matcher }
+import org.specs2.matcher.{ Expectable, MatchFailure, MatchSuccess, Matcher }
 
 import scala.reflect.ClassTag
 
-trait Mockito extends IdiomaticStubbing with PostfixVerifications with ArgumentMatchersSugar with MockitoSpecs2Support {
+trait Mockito extends IdiomaticStubbing with PostfixVerifications with ArgumentMatchersSugar with MockitoCompat {
   def checkCalls[Any] =
     new Matcher[Any] {
       def apply[S <: Any](s: Expectable[S]) =
@@ -32,7 +32,6 @@ trait Mockito extends IdiomaticStubbing with PostfixVerifications with ArgumentM
         }
     }
 
-  override type Verification = MatchResult[Any]
   override def verification(v: => Any): Verification = createExpectable(v).applyMatcher(checkCalls)
 
   implicit def defaultMatcher[T: Equality: ValueClassExtractor](implicit prettifier: Prettifier): DefaultMatcher[T] =
@@ -47,14 +46,6 @@ trait Mockito extends IdiomaticStubbing with PostfixVerifications with ArgumentM
 
   /** create an object supporting 'was' and 'were' methods */
   def there = new Calls
-
-  /**
-   * class supporting 'was' and 'were' methods to forward mockito calls to the CallsMatcher matcher
-   */
-  class Calls {
-    def were[T](calls: => T)(implicit order: VerifyOrder): Verification = macro Specs2VerifyMacro.wasMacro[T, Verification]
-    def was[T](calls: T)(implicit order: VerifyOrder): Verification = macro Specs2VerifyMacro.wasMacro[T, Verification]
-  }
 
   /** no calls made to the mock */
   def noCallsTo[T <: AnyRef](mocks: T*): Unit = ()
@@ -108,12 +99,6 @@ trait Mockito extends IdiomaticStubbing with PostfixVerifications with ArgumentM
   implicit class Specs2Stubbing[T](s: ScalaOngoingStubbing[T]) {
     def thenReturns(value: T, values: T*): ScalaOngoingStubbing[T] = s.andThen(value, values*)
   }
-
-  implicit class MatchResultOps[T](m: MatchResult[T]) {
-    def andThen[O](calls: => O)(implicit order: VerifyOrder): Verification = macro Specs2VerifyMacro.wasMacro[O, Verification]
-  }
-
-  def got[T](calls: => T)(implicit order: VerifyOrder): Verification = macro Specs2VerifyMacro.wasMacro[T, Verification]
 
   def capture[T: ClassTag]: Captor[T] = ArgCaptor[T]
 

--- a/specs2/src/main/scala/org/mockito/specs2/MockitoSpecs2Support.scala
+++ b/specs2/src/main/scala/org/mockito/specs2/MockitoSpecs2Support.scala
@@ -1,7 +1,7 @@
 package org.mockito.specs2
 
 import org.specs2.matcher.MatchersImplicits.*
-import org.specs2.matcher.{ BeEqualTo, Expectations, MatchFailure, Matcher }
+import org.specs2.matcher.*
 
 trait ArgThat {
   implicit def argThat[T](m: org.specs2.matcher.Matcher[T]): T = org.mockito.hamcrest.MockitoHamcrest.argThat(HamcrestMatcherAdapter(m))
@@ -1186,4 +1186,6 @@ trait FunctionArguments extends FunctionArgumentsLowImplicits {
     )
 }
 
-trait MockitoSpecs2Support extends FunctionArguments
+trait MockitoSpecs2Support extends FunctionArguments {
+  type Verification = MatchResult[Any]
+}


### PR DESCRIPTION
Extracting and moving Scala 2 macro to scala-2 dir for specs2 module

I believe this is the last Scala 2 split PR, after that i will start adding Scala 3 implementations bit by bit