### PR TITLE
Refactor: extract DSL keyword constants to shared objects

### DIFF
--- a/macro/src/main/scala-2/org/mockito/Specs2VerifyMacro.scala
+++ b/macro/src/main/scala-2/org/mockito/Specs2VerifyMacro.scala
@@ -1,19 +1,12 @@
 package org.mockito
 
+import org.mockito.MacroConstants.{ WasWere, WordsToNumbers }
 import org.mockito.Utils.*
 import org.mockito.internal.MacroDebug.debugResult
 
 import scala.reflect.macros.blackbox
 
 object Specs2VerifyMacro extends VerificationMacroTransformer {
-  private val WordsToNumbers = Map(
-    "no"    -> 0,
-    "one"   -> 1,
-    "two"   -> 2,
-    "three" -> 3
-  )
-
-  private val WasWere = "(was|were)".r.pattern
 
   def wasMacro[T: c.WeakTypeTag, R](c: blackbox.Context)(calls: c.Expr[T])(order: c.Expr[VerifyOrder]): c.Expr[R] = {
     import c.universe.*

--- a/macro/src/main/scala-2/org/mockito/WhenMacro.scala
+++ b/macro/src/main/scala-2/org/mockito/WhenMacro.scala
@@ -1,8 +1,9 @@
 package org.mockito
 
 import org.mockito.Utils.*
+import org.mockito.WhenDslKeywords.*
 import org.mockito.internal.MacroDebug.debugResult
-import org.mockito.stubbing.{ ScalaFirstStubbing, ScalaOngoingStubbing }
+import org.mockito.stubbing.ScalaOngoingStubbing
 
 import scala.reflect.macros.blackbox
 
@@ -50,9 +51,6 @@ object WhenMacro {
     } else throw new Exception(s"Couldn't recognize invocation ${show(invocation)}")
   }
 
-  private val ShouldReturnOptions                                 = Set("shouldReturn", "mustReturn", "returns")
-  private val FunctionalShouldReturnOptions                       = ShouldReturnOptions.map(_ + "F")
-  private val FunctionalShouldReturnOptions2                      = ShouldReturnOptions.map(_ + "FG")
   def shouldReturn[T: c.WeakTypeTag](c: blackbox.Context): c.Tree = {
     import c.universe.*
 
@@ -87,7 +85,6 @@ object WhenMacro {
     r
   }
 
-  val ShouldCallOptions                                                                                                          = Set("shouldCall", "mustCall", "calls")
   def shouldCallRealMethod[T: c.WeakTypeTag](c: blackbox.Context)(crm: c.Expr[RealMethod.type]): c.Expr[ScalaOngoingStubbing[T]] = {
     import c.universe.*
 
@@ -103,9 +100,6 @@ object WhenMacro {
     r
   }
 
-  private val ShouldThrowOptions                                 = Set("shouldThrow", "mustThrow", "throws")
-  private val FunctionalShouldFailOptions                        = Set("shouldFailWith", "mustFailWith", "failsWith", "raises")
-  private val FunctionalShouldFailOptions2                       = Set("shouldFailWithG", "mustFailWithG", "failsWithG", "raisesG")
   def shouldThrow[T: c.WeakTypeTag](c: blackbox.Context): c.Tree = {
     import c.universe.*
 
@@ -125,9 +119,6 @@ object WhenMacro {
     r
   }
 
-  private val ShouldAnswerOptions                                 = Set("shouldAnswer", "mustAnswer", "answers")
-  private val FunctionalShouldAnswerOptions                       = ShouldAnswerOptions.map(_ + "F")
-  private val FunctionalShouldAnswerOptions2                      = ShouldAnswerOptions.map(_ + "FG")
   def shouldAnswer[T: c.WeakTypeTag](c: blackbox.Context): c.Tree = {
     import c.universe.*
 
@@ -147,7 +138,6 @@ object WhenMacro {
     r
   }
 
-  private val ShouldAnswerPFOptions                                 = Set("shouldAnswerPF", "mustAnswerPF", "answersPF")
   def shouldAnswerPF[T: c.WeakTypeTag](c: blackbox.Context): c.Tree = {
     import c.universe.*
 

--- a/macro/src/main/scala/org/mockito/MacroConstants.scala
+++ b/macro/src/main/scala/org/mockito/MacroConstants.scala
@@ -1,5 +1,6 @@
 package org.mockito
 
+import java.util.regex.Pattern
 import scala.util.matching.Regex
 
 /**
@@ -59,4 +60,13 @@ object MacroConstants {
 
   def isSpecs2Matcher(methodName: String): Boolean =
     Specs2Implicits.pattern.matcher(methodName).matches
+
+  val WordsToNumbers: Map[String, Int] = Map(
+    "no"    -> 0,
+    "one"   -> 1,
+    "two"   -> 2,
+    "three" -> 3
+  )
+
+  val WasWere: Pattern = "(was|were)".r.pattern
 }

--- a/macro/src/main/scala/org/mockito/WhenDslKeywords.scala
+++ b/macro/src/main/scala/org/mockito/WhenDslKeywords.scala
@@ -1,0 +1,22 @@
+package org.mockito
+
+/**
+ * DSL keyword sets for the idiomatic when/stubbing API. Shared across Scala 2 and Scala 3.
+ */
+object WhenDslKeywords {
+  val ShouldReturnOptions: Set[String]            = Set("shouldReturn", "mustReturn", "returns")
+  val FunctionalShouldReturnOptions: Set[String]  = ShouldReturnOptions.map(_ + "F")
+  val FunctionalShouldReturnOptions2: Set[String] = ShouldReturnOptions.map(_ + "FG")
+
+  val ShouldCallOptions: Set[String] = Set("shouldCall", "mustCall", "calls")
+
+  val ShouldThrowOptions: Set[String]           = Set("shouldThrow", "mustThrow", "throws")
+  val FunctionalShouldFailOptions: Set[String]  = Set("shouldFailWith", "mustFailWith", "failsWith", "raises")
+  val FunctionalShouldFailOptions2: Set[String] = Set("shouldFailWithG", "mustFailWithG", "failsWithG", "raisesG")
+
+  val ShouldAnswerOptions: Set[String]            = Set("shouldAnswer", "mustAnswer", "answers")
+  val FunctionalShouldAnswerOptions: Set[String]  = ShouldAnswerOptions.map(_ + "F")
+  val FunctionalShouldAnswerOptions2: Set[String] = ShouldAnswerOptions.map(_ + "FG")
+
+  val ShouldAnswerPFOptions: Set[String] = Set("shouldAnswerPF", "mustAnswerPF", "answersPF")
+}


### PR DESCRIPTION
Extract some constants to shared paths making them available for future Scala 3 use.