### PR TITLE
Scala3 build infra

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -9,3 +9,10 @@ spaces.inImportCurlyBraces = true
 indentOperator.preset = spray
 
 version = 3.10.7
+
+# Use Scala 3 dialect for scala-3 directories
+fileOverride {
+  "glob:**/scala-3/**/*.scala" {
+    runner.dialect = scala3
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 import scala.language.postfixOps
 
 val currentScalaVersion = "2.13.18"
+val scala3Version       = "3.3.7"
 
 inThisBuild(
   Seq(
@@ -22,17 +23,32 @@ lazy val commonSettings =
     // Load version from the file so that Gradle/Shipkit and SBT use the same version
     crossScalaVersions := Seq(currentScalaVersion, "2.12.21"),
     scalafmtOnCompile  := true,
-    scalacOptions ++= Seq(
-      "-unchecked",
-      "-feature",
-      "-deprecation",
-      "-encoding",
-      "UTF-8",
-      "-Xfatal-warnings",
-      "-Xsource:3",
-//      "-Xmacro-settings:mockito-print-when,mockito-print-do-something,mockito-print-verify,mockito-print-expect,mockito-print-captor,mockito-print-matcher,mockito-print-extractor,mockito-print-wrapper,mockito-print-lenient",
-      "-language:reflectiveCalls,implicitConversions,experimental.macros,higherKinds"
-    ),
+    scalacOptions ++= {
+      val common = Seq(
+        "-unchecked",
+        "-feature",
+        "-deprecation",
+        "-encoding",
+        "UTF-8"
+      )
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, _)) =>
+          common ++ Seq(
+            "-Xfatal-warnings",
+            "-Xsource:3",
+            "-Wconf:msg=access modifiers for .copy. method are copied:s",
+//            "-Xmacro-settings:mockito-print-when,mockito-print-do-something,mockito-print-verify,mockito-print-expect,mockito-print-captor,mockito-print-matcher,mockito-print-extractor,mockito-print-wrapper,mockito-print-lenient",
+            "-language:reflectiveCalls,implicitConversions,experimental.macros,higherKinds"
+          )
+        case Some((3, _)) =>
+          common ++ Seq(
+            "-Werror",
+            "-language:reflectiveCalls,implicitConversions,higherKinds"
+          )
+        case _ =>
+          common
+      }
+    },
     scalacOptions ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, 12)) =>
@@ -43,7 +59,12 @@ lazy val commonSettings =
           Seq()
       }
     },
-    Test / scalacOptions += "-Ywarn-value-discard",
+    Test / scalacOptions ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, _)) => Seq("-Ywarn-value-discard")
+        case _            => Seq()
+      }
+    },
     libraryDependencies ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, major)) if major <= 12 =>

--- a/common/src/main/scala/org/mockito/matchers/AllOf.scala
+++ b/common/src/main/scala/org/mockito/matchers/AllOf.scala
@@ -13,10 +13,6 @@ case class AllOf[A] private (matchers: List[ArgumentMatcher[A]]) extends Argumen
       case matcher :: Nil => matcher.toString
       case _              => matchers.mkString("allOf(", ", ", ")")
     }
-
-  // Address "-Xsource:3" warning
-  @deprecated("for bincompat only, do not use", "2.0.1")
-  private[mockito] def copy(matchers: List[ArgumentMatcher[A]] = this.matchers): AllOf[A] = new AllOf(matchers)
 }
 
 object AllOf {

--- a/common/src/main/scala/org/mockito/matchers/ProductOf.scala
+++ b/common/src/main/scala/org/mockito/matchers/ProductOf.scala
@@ -7,11 +7,6 @@ package matchers
 case class ProductOf[A, B] private (ma: ArgumentMatcher[A], mb: ArgumentMatcher[B]) extends ArgumentMatcher[(A, B)] {
   override def matches(ab: (A, B)): Boolean = ab match { case (a, b) => ma.matches(a) && mb.matches(b) }
   override def toString: String             = s"productOf($ma, $mb)"
-
-  // Address "-Xsource:3" warning
-  @deprecated("for bincompat only, do not use", "2.0.1")
-  private[mockito] def copy(ma: ArgumentMatcher[A] = this.ma, mb: ArgumentMatcher[B] = this.mb): ProductOf[A, B] =
-    new ProductOf(ma, mb)
 }
 
 object ProductOf {

--- a/common/src/main/scala/org/mockito/matchers/Transformed.scala
+++ b/common/src/main/scala/org/mockito/matchers/Transformed.scala
@@ -9,11 +9,6 @@ package matchers
 case class Transformed[A, B] private (ma: ArgumentMatcher[A])(f: B => A) extends ArgumentMatcher[B] {
   override def matches(b: B): Boolean = ma.matches(f(b))
   override def toString: String       = s"transformed($ma: $f)"
-
-  // Address "-Xsource:3" warning
-  @deprecated("for bincompat only, do not use", "2.0.1")
-  private[mockito] def copy(ma: ArgumentMatcher[A] = this.ma)(f: B => A = this.f): Transformed[A, B] =
-    new Transformed(ma)(f)
 }
 
 object Transformed {


### PR DESCRIPTION
- Add scala3Version (3.3.7) val to build.sbt (not yet in `crossScalaVersions`)
- Make scalacOptions version-dependent: Scala 2 keeps existing flags, Scala 3 gets `-Werror` and appropriate language imports
- Add `-Wconf` to suppress copy method access modifier warnings in Scala 2
- Guard `-Ywarn-value-discard` behind Scala 2 check
- Add scalafmt dialect override for scala-3/ directories
- Remove deprecated copy method workarounds from `AllOf`, `ProductOf`, `Transformed` (no longer needed with `-Wconf` suppression)