### PR TITLE
Refactor: merge `MockitoEnhancer` and `MockitoEnhancerRuntime`, move Scala-version delta to `DoSomethingCompat`

### DIFF
--- a/common/src/main/scala-2/org/mockito/DoSomethingCompat.scala
+++ b/common/src/main/scala-2/org/mockito/DoSomethingCompat.scala
@@ -1,0 +1,9 @@
+package org.mockito
+
+/**
+ * Scala 2 compatibility hook for DoSomething.
+ *
+ * In Scala 2, unlike Scala 3, <code>doAnswer(() => expr)</code> is dispatched to the by-name overload <code>doAnswer(l: => R)</code>, so no extra overload is needed here. This
+ * trait stays empty and only mirrors the Scala 3 structure.
+ */
+private[mockito] trait DoSomethingCompat

--- a/common/src/main/scala-2/org/mockito/MockCreator.scala
+++ b/common/src/main/scala-2/org/mockito/MockCreator.scala
@@ -25,6 +25,9 @@ private[mockito] trait MockCreator extends MockCreatorRuntime {
   def mock[T <: AnyRef: ClassTag: WeakTypeTag](implicit defaultAnswer: DefaultAnswer, $pt: Prettifier): T =
     mock[T](defaultAnswer)
 
+  /**
+   * Creates a mock using a raw Mockito <code>Answer</code> by wrapping it in a scala-mockito <code>DefaultAnswer</code>.
+   */
   def mock[T <: AnyRef: ClassTag: WeakTypeTag](defaultAnswer: Answer[?])(implicit $pt: Prettifier): T =
     mock[T](DefaultAnswer(defaultAnswer))
 
@@ -67,12 +70,19 @@ private[mockito] trait MockCreator extends MockCreatorRuntime {
   def mock[T <: AnyRef: ClassTag: WeakTypeTag](name: String)(implicit defaultAnswer: DefaultAnswer, $pt: Prettifier): T =
     mock(withSettings.name(name))
 
+  /**
+   * Creates a spy from a real instance via mock settings (spied instance + <code>CallsRealMethods</code>). When <code>lenient</code> is true, the spy is created with
+   * <code>Strictness.LENIENT</code>.
+   */
   def spy[T <: AnyRef: ClassTag: WeakTypeTag](realObj: T, lenient: Boolean = false)(implicit $pt: Prettifier): T = {
     val mockSettings: MockSettings = withSettings(CallsRealMethods).spiedInstance(realObj)
     val settings                   = if (lenient) mockSettings.strictness(Strictness.LENIENT) else mockSettings
     mock[T](settings)
   }
 
+  /**
+   * Internal helper that creates a mock and adds extra interfaces discovered from the refined type.
+   */
   private[mockito] def createMock[T <: AnyRef: ClassTag: WeakTypeTag](
       mockSettings: MockSettings,
       mockHandler: (MockCreationSettings[T], Prettifier) => MockHandler[T] = (settings: MockCreationSettings[T], pt: Prettifier) => ScalaMockHandler(settings)(pt)

--- a/common/src/main/scala-2/org/mockito/MockitoEnhancer.scala
+++ b/common/src/main/scala-2/org/mockito/MockitoEnhancer.scala
@@ -1,9 +1,0 @@
-package org.mockito
-
-/**
- * Scala 2 specific trait that provides object mocking functionality. Extends MockCreator (Scala 2 version with WeakTypeTag) and MockitoEnhancerRuntime (shared utilities including
- * withObject methods).
- *
- * This is a thin compatibility layer - all actual functionality is in MockCreator and MockitoEnhancerRuntime.
- */
-private[mockito] trait MockitoEnhancer extends MockCreator with MockitoEnhancerRuntime

--- a/common/src/main/scala/org/mockito/MockitoAPI.scala
+++ b/common/src/main/scala/org/mockito/MockitoAPI.scala
@@ -86,7 +86,7 @@ private[mockito] trait MockCreatorRuntime {
 }
 
 //noinspection MutatorLikeMethodIsParameterless
-private[mockito] trait DoSomething {
+private[mockito] trait DoSomething extends DoSomethingCompat {
 
   /**
    * Delegates the call to <code>Mockito.doReturn(toBeReturned, toBeReturnedNext)</code> but fixes the following compiler issue that happens because the overloaded vararg on the
@@ -482,9 +482,9 @@ private[mockito] trait DoSomething {
 }
 
 /**
- * Runtime support for MockitoEnhancer with utility methods that don't require WeakTypeTag. Shared across Scala 2 and Scala 3. Version-specific MockitoEnhancer traits extend this.
+ * Support for object-mocking syntax and utility methods that don't require WeakTypeTag.
  */
-private[mockito] trait MockitoEnhancerRuntime extends MockCreatorRuntime {
+private[mockito] trait MockitoEnhancer extends MockCreator {
 
   /**
    * Delegates to <code>Mockito.reset(T... mocks)</code>, but restores the default stubs that deal with default argument values

--- a/core/src/main/scala/org/mockito/MockitoSugar.scala
+++ b/core/src/main/scala/org/mockito/MockitoSugar.scala
@@ -1,6 +1,6 @@
 package org.mockito
 
-trait MockitoSugar extends MockitoEnhancer with DoSomething with Verifications with Rest with ScalacticSerialisableHack
+trait MockitoSugar extends Rest with ScalacticSerialisableHack
 
 /**
  * Simple object to allow the usage of the trait without mixing it in


### PR DESCRIPTION
It happened that the only real delta between Scala 2 and 3 for `MockitoEnhancer` was in `DoSomething` mix-in due to Scala 3 different resolution of `doAnswer(() => expr)`, so I'm merging those back and adding thing `DoSomethingCompat` layer, which will be implemented later for Scala 3
Also, add some missing ScalaDocs and simplify `MockitoSugar` to inherit from `Rest` which already brings in `MockitoEnhancer with DoSomething with Verifications`