### PR TITLE
Add cache-backed Scala 3 ReflectionUtils in common

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -165,10 +165,12 @@ lazy val common = (project in file("common"))
   .settings(
     commonSettings,
     noPublishingSettings,
+    crossScalaVersions += scala3Version,
     libraryDependencies ++= Dependencies.commonLibraries ++
       Dependencies.scalaReflection.value ++ Seq(
         Dependencies.catsLaws   % "test",
-        Dependencies.scalacheck % "test"
+        Dependencies.scalacheck % "test",
+        Dependencies.scalatest  % "test"
       )
   )
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# TODO: Scala 3 modules are not in root aggregate, so +test does not cross-build them for 3.3.7.
-#  As each module gains Scala 3 support, add it to the +<module>/test command below.
+# TODO: Scala 3 modules are not all in root aggregate, so +test does not cross-build every module for 3.3.7.
+#  As each module gains Scala 3 support, add it to the explicit +<module>/test commands below.
 #  Once all modules support Scala 3, add scala3Version to commonSettings crossScalaVersions
 #  and remove the per-module commands.
-java -Xms512M -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=192m -Dfile.encoding=UTF-8 -jar sbt/sbt-launch.jar -Dsbt.parser.simple=true clean +test +macroCommon/test 'set every publishTo := Some(Resolver.file("local-repo", file("target/dist")))' '+ publish'
+java -Xms512M -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=192m -Dfile.encoding=UTF-8 -jar sbt/sbt-launch.jar -Dsbt.parser.simple=true clean +test +common/test +macroCommon/test 'set every publishTo := Some(Resolver.file("local-repo", file("target/dist")))' '+ publish'

--- a/common/src/main/scala-3/org/mockito/DoSomethingCompat.scala
+++ b/common/src/main/scala-3/org/mockito/DoSomethingCompat.scala
@@ -1,0 +1,12 @@
+package org.mockito
+
+import org.mockito.internal.ValueClassExtractor
+import org.mockito.stubbing.Stubber
+
+import scala.annotation.targetName
+
+private[mockito] trait DoSomethingCompat {
+  @targetName("doAnswerFunction0")
+  def doAnswer[R: ValueClassExtractor](f: () => R): Stubber =
+    Mockito.doAnswer(invocationToAnswer[R](_ => f()))
+}

--- a/common/src/main/scala-3/org/mockito/MockCreator.scala
+++ b/common/src/main/scala-3/org/mockito/MockCreator.scala
@@ -1,0 +1,61 @@
+package org.mockito
+
+import org.mockito.internal.MockMethodMetadata
+import org.mockito.invocation.MockHandler
+import org.mockito.mock.MockCreationSettings
+import org.mockito.quality.Strictness
+import org.mockito.stubbing.{ Answer, CallsRealMethods, DefaultAnswer }
+import org.scalactic.Prettifier
+
+import scala.annotation.targetName
+import scala.reflect.ClassTag
+
+/**
+ * Scala 3 mock/spy creation facade.
+ *
+ * Design notes:
+ *   - `@targetName` is used on overloads so generated JVM method names stay unique and stable.
+ *   - `inline` keeps the concrete `T` at call sites, allowing compile-time metadata extraction.
+ *   - `createMock` registers per-method metadata via [[org.mockito.internal.MockMethodMetadata.registerByNameAndVarArgInfo]] before delegating to runtime creation; this feeds
+ *     `ReflectionUtils`/`ScalaMockHandler` with by-name, vararg and return metadata.
+ */
+private[mockito] trait MockCreator extends MockCreatorRuntime {
+
+  inline def mock[T <: AnyRef: ClassTag](using defaultAnswer: DefaultAnswer, $pt: Prettifier): T =
+    mock[T](defaultAnswer)
+
+  @targetName("mockWithAnswer")
+  inline def mock[T <: AnyRef: ClassTag](defaultAnswer: Answer[?])(using $pt: Prettifier): T =
+    mock[T](DefaultAnswer(defaultAnswer))
+
+  @targetName("mockWithDefaultAnswer")
+  inline def mock[T <: AnyRef: ClassTag](defaultAnswer: DefaultAnswer)(using $pt: Prettifier): T =
+    mock[T](withSettings(defaultAnswer))
+
+  @targetName("mockWithSettings")
+  inline def mock[T <: AnyRef: ClassTag](mockSettings: MockSettings)(using $pt: Prettifier): T =
+    createMock[T](mockSettings, (settings, pt) => org.mockito.internal.handler.ScalaMockHandler(settings)(pt))
+
+  @targetName("mockWithName")
+  inline def mock[T <: AnyRef: ClassTag](name: String)(using defaultAnswer: DefaultAnswer, $pt: Prettifier): T =
+    mock[T](withSettings.name(name))
+
+  inline def spy[T <: AnyRef: ClassTag](realObj: T, lenient: Boolean = false)(using $pt: Prettifier): T = {
+    val mockSettings: MockSettings = withSettings(CallsRealMethods).spiedInstance(realObj)
+    val settings                   = if (lenient) mockSettings.strictness(Strictness.LENIENT) else mockSettings
+    mock[T](settings)
+  }
+
+  /**
+   * Internal creation path that records metadata for `T` (compile-time) and then creates the mock (runtime).
+   *
+   * Registration must happen before first invocation handling so argument unwrapping and return-type classification can use cache data immediately.
+   */
+  private[mockito] inline def createMock[T <: AnyRef: ClassTag](
+      mockSettings: MockSettings,
+      mockHandler: (MockCreationSettings[T], Prettifier) => MockHandler[T]
+  )(using $pt: Prettifier): T = {
+    MockMethodMetadata.registerByNameAndVarArgInfo[T]
+    createMock[T](mockSettings, ReflectionUtils.extraInterfaces[T], mockHandler)
+  }
+}

--- a/common/src/main/scala-3/org/mockito/ReflectionUtils.scala
+++ b/common/src/main/scala-3/org/mockito/ReflectionUtils.scala
@@ -1,0 +1,79 @@
+package org.mockito
+
+import org.mockito.JavaReflectionUtils.resolveWithJavaGenerics
+import org.mockito.internal.MockMethodMetadata
+import org.mockito.internal.MockMetadataCache
+import org.mockito.invocation.InvocationOnMock
+
+import java.lang.reflect.{ Method, TypeVariable }
+import scala.reflect.ClassTag
+
+object ReflectionUtils {
+
+  /**
+   * Get the return type of a method invocation, resolving generics when JVM erasure yields `Object`.
+   *
+   * Scala 3 strategy (in order):
+   *   1. compile-time metadata from [[MockMetadataCache.getReturnType]]
+   *   2. runtime Java generic resolution via [[org.mockito.JavaReflectionUtils.resolveWithJavaGenerics]]
+   *   3. raw JVM return type (`Object`) as a fallback
+   *
+   * This is conceptually equivalent to Scala 2's "recover a more specific type than Object" path, but uses compile-time metadata instead of runtime Scala reflection
+   * (`WeakTypeTag`/`scala.reflect.runtime.universe`).
+   */
+  private[mockito] def returnType(invocation: InvocationOnMock): Class[?] = {
+    val method         = invocation.method
+    val javaReturnType = method.getReturnType
+
+    if (javaReturnType == classOf[Object])
+      MockMetadataCache
+        .getReturnType(method)
+        .orElse(resolveWithJavaGenerics(invocation))
+        .getOrElse(javaReturnType)
+    else javaReturnType
+  }
+
+  /**
+   * Check if a method should be treated as value-like for null/default handling.
+   *
+   * Scala 3 strategy (in order):
+   *   1. primitive fast-path (`returnType.isPrimitive`)
+   *   2. compile-time metadata from [[MockMetadataCache.getReturnsValueClass]]
+   *   3. conservative JVM fallback:
+   *      - generic `TypeVariable` return => `false` (erased/ambiguous)
+   *      - otherwise `classOf[AnyVal].isAssignableFrom(returnType)`
+   *
+   * This mirrors Scala 2 intent ("identify returns that require value-like handling") while replacing runtime Scala reflection with compile-time metadata plus conservative runtime
+   * checks.
+   */
+  private[mockito] def returnsValueClass(invocation: InvocationOnMock): Boolean =
+    val method     = invocation.method
+    val returnType = method.getReturnType
+    returnType.isPrimitive || MockMetadataCache
+      .getReturnsValueClass(method)
+      .getOrElse {
+        method.getGenericReturnType match {
+          case _: TypeVariable[?] => false
+          case _                  => classOf[AnyVal].isAssignableFrom(returnType)
+        }
+      }
+
+  /**
+   * Extract extra interfaces from an intersection/refined type at compile time.
+   *
+   * Example: `mock[Foo & Bar]` yields `List(classOf[Bar])`.
+   */
+  inline def extraInterfaces[T: ClassTag]: List[Class[?]] =
+    MockMethodMetadata.extraInterfacesImpl[T]
+
+  /**
+   * Find methods with lazy (by-name) parameters or varargs. In Scala 3, this reads from metadata cache populated at compile time by the [[org.mockito.internal.MockMethodMetadata]]
+   * inline macro called during mock creation.
+   *
+   * Returned indices are consumed by `ScalaMockHandler` to unwrap by-name/vararg arguments while keeping plain `Function0` arguments distinct.
+   */
+  def methodsWithLazyOrVarArgs(classes: Seq[Class[?]]): Seq[(Method, Set[Int])] =
+    classes.flatMap { clazz =>
+      MockMetadataCache.getByName(clazz).getOrElse(Seq.empty)
+    }
+}

--- a/common/src/test/scala-3/org/mockito/MockCreatorMetadataRegistrationTest.scala
+++ b/common/src/test/scala-3/org/mockito/MockCreatorMetadataRegistrationTest.scala
@@ -1,0 +1,40 @@
+package org.mockito
+
+import org.mockito.internal.MockMetadataCache
+import org.scalactic.Prettifier
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+private[mockito] case class MCR_ValueId(value: Int) extends AnyVal
+
+private[mockito] trait MCR_MetadataTarget {
+  type Alias = String
+  def byNameAndVarArg(x: => Int, ys: String*): Unit
+  def plainFunction0(f: () => String): String
+  def aliasReturn: Alias
+  def valueId: MCR_ValueId
+}
+
+class MockCreatorMetadataRegistrationTest extends AnyWordSpec with Matchers {
+  private object TestCreator extends MockCreator
+
+  implicit private val prettifier: Prettifier = Prettifier.default
+
+  "MockCreator.createMock" should {
+    "register metadata via MockMethodMetadata before creating the mock" in {
+      val mocked = TestCreator.mock[MCR_MetadataTarget](DefaultAnswers.ReturnsDefaults)
+      mocked should not be null
+
+      val byNameMethod = classOf[MCR_MetadataTarget].getMethods.find(_.getName == "byNameAndVarArg").get
+      val byNameInfos  = MockMetadataCache.getByName(classOf[MCR_MetadataTarget])
+      byNameInfos should not be empty
+      byNameInfos.get.toMap.get(byNameMethod) shouldBe Some(Set(0, 1))
+      byNameInfos.get.exists(_._1.getName == "plainFunction0") shouldBe false
+
+      val aliasMethod   = classOf[MCR_MetadataTarget].getMethod("aliasReturn")
+      val valueIdMethod = classOf[MCR_MetadataTarget].getMethod("valueId")
+      MockMetadataCache.getReturnType(aliasMethod) shouldBe Some(classOf[String])
+      MockMetadataCache.getReturnsValueClass(valueIdMethod) shouldBe Some(true)
+    }
+  }
+}

--- a/common/src/test/scala-3/org/mockito/ReflectionUtilsTest.scala
+++ b/common/src/test/scala-3/org/mockito/ReflectionUtilsTest.scala
@@ -1,0 +1,114 @@
+package org.mockito
+
+import org.mockito.internal.MockMetadataCache
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+// ── test models (package-level to avoid path-dependent type issues with macro) ──
+
+private[mockito] case class RUT_IntId(value: Int)     extends AnyVal
+private[mockito] case class RUT_UserId(value: String) extends AnyVal
+
+private[mockito] trait RUT_WithPrimitiveBacked           { def id: RUT_IntId                       }
+private[mockito] trait RUT_WithReferenceBacked           { def id: RUT_UserId                      }
+private[mockito] trait RUT_WithGenericBound[T <: AnyVal] { def id(v: T): T                         }
+private[mockito] trait RUT_WithTypeMemberBound           { type Id <: AnyVal; def id: Id           }
+private[mockito] trait RUT_WithStringTypeAlias           { type Alias = String; def getName: Alias }
+private[mockito] trait RUT_WithStringReturn              { def getName: String                     }
+private[mockito] trait RUT_WithByNameAndVarArg           { def foo(x: => Int, ys: String*): Unit   }
+private[mockito] trait RUT_WithByNameAndFunction0        {
+  def byNameArg(x: => String): String
+  // Deliberately present to prove metadata marks only by-name params, not plain Function0 params.
+  def function0Arg(f: () => String): String
+}
+
+/**
+ * Scala 3 tests for [[MockMetadataCache]] and [[ReflectionUtils]].
+ *
+ * Tests register metadata explicitly in [[MockMetadataCache]], then assert cache entries and [[ReflectionUtils]] behavior.
+ *
+ * NOTE: plain ScalaTest assertions — NOT property-based tests.
+ */
+class ReflectionUtilsTest extends AnyWordSpec with Matchers {
+  private val primitiveMethod          = classOf[RUT_WithPrimitiveBacked].getMethod("id")
+  private val referenceMethod          = classOf[RUT_WithReferenceBacked].getMethod("id")
+  private val typeMemberMethod         = classOf[RUT_WithTypeMemberBound].getMethod("id")
+  private val genericBoundMethod       = classOf[RUT_WithGenericBound[RUT_IntId]].getMethod("id", classOf[Object])
+  private val stringAliasMethod        = classOf[RUT_WithStringTypeAlias].getMethod("getName")
+  private val stringReturnMethod       = classOf[RUT_WithStringReturn].getMethod("getName")
+  private val byNameAndVarArgMethod    = classOf[RUT_WithByNameAndVarArg].getMethods.find(_.getName == "foo").get
+  private val byNameAndFunction0Method = classOf[RUT_WithByNameAndFunction0].getMethod("byNameArg", classOf[scala.Function0[?]])
+
+  MockMetadataCache.registerReturnsValueClass(
+    Seq(
+      primitiveMethod    -> true,
+      referenceMethod    -> true,
+      typeMemberMethod   -> false,
+      genericBoundMethod -> false
+    )
+  )
+  MockMetadataCache.registerReturnType(
+    Seq(
+      stringAliasMethod  -> classOf[String],
+      stringReturnMethod -> classOf[String]
+    )
+  )
+  MockMetadataCache.registerByName(
+    classOf[RUT_WithByNameAndVarArg],
+    Seq(byNameAndVarArgMethod -> Set(0, 1))
+  )
+  MockMetadataCache.registerByName(
+    classOf[RUT_WithByNameAndFunction0],
+    Seq(byNameAndFunction0Method -> Set(0))
+  )
+
+  "MockMetadataCache returnsValueClass registration" should {
+
+    "be true for primitive-backed value class" in {
+      MockMetadataCache.getReturnsValueClass(primitiveMethod) shouldBe Some(true)
+    }
+
+    "be true for reference-backed value class" in {
+      MockMetadataCache.getReturnsValueClass(referenceMethod) shouldBe Some(true)
+    }
+
+    "be false for abstract type member bounded by AnyVal" in {
+      MockMetadataCache.getReturnsValueClass(typeMemberMethod) shouldBe Some(false)
+    }
+
+    "be false for generic AnyVal bound method returning type variable" in {
+      MockMetadataCache.getReturnsValueClass(genericBoundMethod) shouldBe Some(false)
+    }
+  }
+
+  "MockMetadataCache returnType registration" should {
+
+    "resolve String type alias to classOf[String]" in {
+      MockMetadataCache.getReturnType(stringAliasMethod) shouldBe Some(classOf[String])
+    }
+
+    "record classOf[String] for plain String return" in {
+      MockMetadataCache.getReturnType(stringReturnMethod) shouldBe Some(classOf[String])
+    }
+  }
+
+  "ReflectionUtils.methodsWithLazyOrVarArgs" should {
+
+    "detect by-name (idx=0) and vararg (idx=1) after macro registration" in {
+      val methodInfos = ReflectionUtils.methodsWithLazyOrVarArgs(Seq(classOf[RUT_WithByNameAndVarArg]))
+      methodInfos should not be empty
+      val (_, indices) = methodInfos.head
+      indices should contain(0)
+      indices should contain(1)
+    }
+
+    "not treat Function0 arguments as by-name" in {
+      val methodInfos = ReflectionUtils.methodsWithLazyOrVarArgs(Seq(classOf[RUT_WithByNameAndFunction0]))
+      methodInfos.size shouldBe 1
+      val (method, indices) = methodInfos.head
+      method.getName shouldBe "byNameArg"
+      indices shouldBe Set(0)
+    }
+  }
+
+}

--- a/macro-common/src/main/scala-3/org/mockito/internal/MockMetadataCache.scala
+++ b/macro-common/src/main/scala-3/org/mockito/internal/MockMetadataCache.scala
@@ -1,0 +1,46 @@
+package org.mockito.internal
+
+import java.lang.reflect.Method
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Runtime cache for per-method mock metadata. Populated at compile time via [[org.mockito.internal.MockMethodMetadata]] inline/macro calls at each `mock[T]` call site.
+ *
+ * Keys and contract:
+ *   - `byName`: keyed by declaring `Class[?]`, stores `Seq[(Method, Set[Int])]`:
+ *       - outer `Seq`: one entry per method on that class with metadata
+ *       - inner `Set[Int]`: zero-based parameter indices that are by-name or vararg for that method
+ *         (example: for `def foo(x: => Int, ys: String*, z: () => String)`, indices are `Set(0, 1)`; `z` is plain `Function0`, so excluded)
+ *   - `returnsValueClass`: keyed by `Method`, stores whether the declared Scala return type extends `AnyVal`.
+ *   - `returnType`: keyed by `Method`, stores the concrete declared return class when JVM erasure gives `Object` but the Scala source type is more specific (e.g. abstract type
+ *     aliases, path-dependent types).
+ */
+object MockMetadataCache {
+  private val byNameCache            = new ConcurrentHashMap[Class[?], Seq[(Method, Set[Int])]]()
+  private val returnsValueClassCache = new ConcurrentHashMap[Method, java.lang.Boolean]()
+  private val returnTypeCache        = new ConcurrentHashMap[Method, Class[?]]()
+
+  /** Get by-name/vararg metadata for a class: `Seq[(method, zero-based by-name/vararg indices)]`, if registered. */
+  def getByName(clazz: Class[?]): Option[Seq[(Method, Set[Int])]] =
+    Option(byNameCache.get(clazz))
+
+  /** Register by-name/vararg metadata (`Set[Int]` are zero-based parameter indices) once per class (idempotent best-effort). */
+  def registerByName(clazz: Class[?], info: Seq[(Method, Set[Int])]): Unit =
+    byNameCache.putIfAbsent(clazz, info)
+
+  /** Get value-like return classification for a method, if registered. */
+  def getReturnsValueClass(method: Method): Option[Boolean] =
+    Option(returnsValueClassCache.get(method)).map(_.booleanValue())
+
+  /** Register value-like return classification for methods (first writer wins). */
+  def registerReturnsValueClass(info: Seq[(Method, Boolean)]): Unit =
+    info.foreach { case (method, v) => returnsValueClassCache.putIfAbsent(method, v) }
+
+  /** Get concrete return class metadata for an erased/ambiguous method signature, if registered. */
+  def getReturnType(method: Method): Option[Class[?]] =
+    Option(returnTypeCache.get(method))
+
+  /** Register concrete return classes for methods (first writer wins). */
+  def registerReturnType(info: Seq[(Method, Class[?])]): Unit =
+    info.foreach { case (method, cls) => returnTypeCache.putIfAbsent(method, cls) }
+}

--- a/macro-common/src/main/scala-3/org/mockito/internal/MockMethodMetadata.scala
+++ b/macro-common/src/main/scala-3/org/mockito/internal/MockMethodMetadata.scala
@@ -1,0 +1,253 @@
+package org.mockito.internal
+
+import scala.collection.mutable
+import scala.quoted.*
+import scala.reflect.ClassTag
+
+/**
+ * Scala 3 compile-time metadata extractor for mock method handling.
+ *
+ * At each `mock[T]` call site, this macro inspects `T` and records:
+ *   - by-name / vararg parameter indices
+ *   - whether a declared return type is value-like (`AnyVal`)
+ *   - recoverable concrete return classes for erased `Object` signatures
+ *
+ * The extracted metadata is stored in [[org.mockito.internal.MockMetadataCache]] and consumed at runtime by `ReflectionUtils` and `ScalaMockHandler`.
+ */
+object MockMethodMetadata {
+
+  /** Entry point called from Scala 3 `MockCreator` during mock creation. */
+  inline def registerByNameAndVarArgInfo[T](using classTag: ClassTag[T]): Unit = ${ registerImpl[T]('classTag) }
+
+  /** Macro implementation that inspects `T` and emits cache-registration runtime code. */
+  def registerImpl[T: Type](classTagExpr: Expr[ClassTag[T]])(using Quotes): Expr[Unit] = {
+    import quotes.reflect.*
+
+    case class MethodInfo(
+        name: String,
+        jvmParamTypes: List[Expr[Class[?]]],
+        byNameOrVarArgIndices: Set[Int],
+        returnsValueClass: Boolean,
+        returnTypeClassOpt: Option[Expr[Class[?]]]
+    )
+
+    case class ParamInfo(tpe: TypeRepr, index: Int, isByName: Boolean, isVarArg: Boolean)
+
+    def resultTypeOf(tpe: TypeRepr): TypeRepr = tpe match {
+      case MethodType(_, _, resultType) => resultTypeOf(resultType)
+      case PolyType(_, _, resultType)   => resultTypeOf(resultType)
+      case other                        => other
+    }
+
+    def isByNameParam(tpe: TypeRepr): Boolean = tpe match {
+      case ByNameType(_) => true
+      case _             => false
+    }
+
+    def isVarArgParam(tpe: TypeRepr): Boolean = tpe match {
+      case AnnotatedType(_, annot) if annot.tpe.typeSymbol.fullName == "scala.annotation.internal.Repeated" => true
+      case other if other.typeSymbol.fullName == "scala.<repeated>"                                         => true
+      case _                                                                                                => false
+    }
+
+    def collectParams(tpe: TypeRepr, baseIndex: Int): List[ParamInfo] =
+      tpe match {
+        case MethodType(_, paramTypes, resultType) =>
+          val params = paramTypes.zipWithIndex.map { case (paramType, index) =>
+            ParamInfo(paramType, baseIndex + index, isByNameParam(paramType), isVarArgParam(paramType))
+          }
+          params ++ collectParams(resultType, baseIndex + paramTypes.length)
+        case PolyType(_, _, resultType) =>
+          collectParams(resultType, baseIndex)
+        case _ => Nil
+      }
+
+    def declaredOrResolvedReturnType(methodSym: Symbol, methodType: TypeRepr): TypeRepr =
+      methodSym.tree match {
+        case dd: DefDef => dd.returnTpt.tpe
+        case _          => resultTypeOf(methodType)
+      }
+
+    def returnsValueClassFor(normalized: TypeRepr): Boolean = {
+      val returnSym = normalized.typeSymbol
+      returnSym.isClassDef && returnSym != defn.AnyValClass && (normalized <:< TypeRepr.of[AnyVal])
+    }
+
+    def returnTypeClassFor(normalized: TypeRepr): Option[Expr[Class[?]]] = {
+      val returnSym = normalized.typeSymbol
+      if (
+        returnSym.isClassDef &&
+        !(normalized =:= TypeRepr.of[Any]) &&
+        !(normalized =:= TypeRepr.of[AnyRef]) &&
+        !(normalized =:= TypeRepr.of[Nothing]) &&
+        !(normalized =:= TypeRepr.of[Null])
+      ) Some(jvmClassExpr(normalized))
+      else None
+    }
+
+    def javaVarArgElementType(paramType: TypeRepr): TypeRepr =
+      paramType match {
+        case AnnotatedType(underlying, _) =>
+          underlying match {
+            case AppliedType(_, List(elem)) => elem
+            case _                          => TypeRepr.of[Object]
+          }
+        case AppliedType(_, List(elem)) => elem
+        case _                          => TypeRepr.of[Object]
+      }
+
+    def jvmParamTypeExpr(param: ParamInfo, isJavaMethod: Boolean): Expr[Class[?]] =
+      if (param.isByName) '{ classOf[scala.Function0[?]] }
+      else if (param.isVarArg) {
+        if (isJavaMethod) {
+          // Java varargs use array types at JVM level, not Seq.
+          val elemClassExpr = jvmClassExpr(javaVarArgElementType(param.tpe))
+          '{ java.lang.reflect.Array.newInstance($elemClassExpr, 0).getClass }
+        } else '{ classOf[scala.collection.immutable.Seq[?]] }
+      } else jvmClassExpr(param.tpe)
+
+    // Phase 1: compile-time analysis of T and its inherited declarations.
+    def collectMethodInfos(tpe: TypeRepr, typeSymbol: Symbol): List[MethodInfo] = {
+      val allMethods = {
+        val seen = mutable.Set.empty[String] // track by fullName to avoid duplicates
+        (typeSymbol.declarations ++ tpe.baseClasses.flatMap(_.declarations))
+          .filter(symbol => symbol.isDefDef && !symbol.isClassConstructor && seen.add(symbol.fullName))
+      }
+
+      allMethods.flatMap { methodSym =>
+        val methodType           = tpe.memberType(methodSym)
+        val isJavaMethod         = methodSym.flags.is(Flags.JavaDefined)
+        val params               = collectParams(methodType, 0)
+        val byNameOrVarArgFields = params.collect { case param if param.isByName || param.isVarArg => param.index }.toSet
+        val normalizedReturnType = declaredOrResolvedReturnType(methodSym, methodType).dealias.simplified
+        val jvmParamTypes        = params.map(param => jvmParamTypeExpr(param, isJavaMethod))
+        Some(
+          MethodInfo(
+            methodSym.name,
+            jvmParamTypes,
+            byNameOrVarArgFields,
+            returnsValueClassFor(normalizedReturnType),
+            returnTypeClassFor(normalizedReturnType)
+          )
+        )
+      }
+    }
+
+    // Phase 2: generate serialized registration payload that can be consumed at runtime.
+    def buildRegistrationsExpr(methodInfos: List[MethodInfo]): Expr[List[(String, List[Class[?]], Set[Int], Boolean, Option[Class[?]])]] = {
+      val registrations = methodInfos.map { info =>
+        val nameExpr              = Expr(info.name)
+        val paramTypesExpr        = Expr.ofList(info.jvmParamTypes)
+        val indicesExpr           = Expr(info.byNameOrVarArgIndices)
+        val returnsValueClassExpr = Expr(info.returnsValueClass)
+        val returnTypeClassExpr   = info.returnTypeClassOpt match {
+          case Some(returnTypeClass) => '{ Some($returnTypeClass) }
+          case None                  => '{ None }
+        }
+        '{ ($nameExpr, $paramTypesExpr, $indicesExpr, $returnsValueClassExpr, $returnTypeClassExpr) }
+      }
+      Expr.ofList(registrations)
+    }
+
+    // Phase 3: runtime method lookup and cache registration.
+    def emitRuntimeRegistration(
+        classTagExpr: Expr[ClassTag[T]],
+        registrationsExpr: Expr[List[(String, List[Class[?]], Set[Int], Boolean, Option[Class[?]])]]
+    ): Expr[Unit] = {
+      val classExpr = '{ $classTagExpr.runtimeClass }
+      '{
+        val clazz = $classExpr
+        if (clazz != classOf[Any]) {
+          val infos               = $registrationsExpr
+          val resolvedMethodInfos = infos.flatMap { case (name, paramTypes, indices, returnsValueClass, returnTypeClassOpt) =>
+            try {
+              val method = clazz.getMethod(name, paramTypes*)
+              Some((method, indices, returnsValueClass, returnTypeClassOpt))
+            } catch {
+              case _: NoSuchMethodException => None
+            }
+          }
+
+          val byNameInfos =
+            resolvedMethodInfos.collect { case (method, indices, _, _) if indices.nonEmpty => (method, indices) }
+          if (byNameInfos.nonEmpty) MockMetadataCache.registerByName(clazz, byNameInfos)
+
+          if (resolvedMethodInfos.nonEmpty)
+            MockMetadataCache.registerReturnsValueClass(
+              resolvedMethodInfos.map { case (method, _, returnsValueClass, _) => (method, returnsValueClass) }
+            )
+
+          val returnTypeInfos = resolvedMethodInfos.collect { case (method, _, _, Some(returnTypeClass)) =>
+            (method, returnTypeClass)
+          }
+          if (returnTypeInfos.nonEmpty) MockMetadataCache.registerReturnType(returnTypeInfos)
+        }
+      }
+    }
+
+    val tpe         = TypeRepr.of[T].dealias
+    val methodInfos = collectMethodInfos(tpe, tpe.typeSymbol)
+
+    if (methodInfos.isEmpty) '{ () } else emitRuntimeRegistration(classTagExpr, buildRegistrationsExpr(methodInfos))
+  }
+
+  /**
+   * Convert a Scala `TypeRepr` to a JVM `Class` expression.
+   *
+   * Primitive types map to `TYPE` singletons; reference types resolve through `Class.forName`.
+   */
+  private def jvmClassExpr(using Quotes)(tpe: quotes.reflect.TypeRepr): Expr[Class[?]] = {
+    import quotes.reflect.*
+    tpe.dealias.simplified.widen match {
+      case t if t =:= TypeRepr.of[Boolean] => '{ java.lang.Boolean.TYPE }
+      case t if t =:= TypeRepr.of[Byte]    => '{ java.lang.Byte.TYPE }
+      case t if t =:= TypeRepr.of[Short]   => '{ java.lang.Short.TYPE }
+      case t if t =:= TypeRepr.of[Int]     => '{ java.lang.Integer.TYPE }
+      case t if t =:= TypeRepr.of[Long]    => '{ java.lang.Long.TYPE }
+      case t if t =:= TypeRepr.of[Float]   => '{ java.lang.Float.TYPE }
+      case t if t =:= TypeRepr.of[Double]  => '{ java.lang.Double.TYPE }
+      case t if t =:= TypeRepr.of[Char]    => '{ java.lang.Character.TYPE }
+      case t if t =:= TypeRepr.of[Unit]    => '{ java.lang.Void.TYPE }
+      case t                               =>
+        val name     = t.typeSymbol.fullName
+        val nameExpr = Expr(name)
+        '{
+          try Class.forName($nameExpr)
+          catch { case _: Exception => classOf[Object] }
+        }
+    }
+  }
+
+  /**
+   * Extract runtime classes from an intersection/refined type (`Foo & Bar`).
+   *
+   * Returns only extra interfaces (primary runtime class excluded). Example: `mock[Foo & Bar]` yields `List(classOf[Bar])`.
+   */
+  inline def extraInterfacesImpl[T](using classTag: ClassTag[T]): List[Class[?]] = ${ extractExtraInterfaces[T]('classTag) }
+
+  /** Macro backend for [[extraInterfacesImpl]]. */
+  private def extractExtraInterfaces[T: Type](classTagExpr: Expr[ClassTag[T]])(using Quotes): Expr[List[Class[?]]] = {
+    import quotes.reflect.*
+
+    def collectTypes(tpe: TypeRepr): List[TypeRepr] = tpe.dealias match {
+      case AndType(left, right) => collectTypes(left) ++ collectTypes(right)
+      case other                => List(other)
+    }
+
+    val allTypes   = collectTypes(TypeRepr.of[T])
+    val classExprs = allTypes.map { t =>
+      val name     = t.typeSymbol.fullName
+      val nameExpr = Expr(name)
+      '{
+        try Some(Class.forName($nameExpr))
+        catch { case _: Exception => None }
+      }
+    }
+    val listExpr = Expr.ofList(classExprs)
+
+    '{
+      val primary = $classTagExpr.runtimeClass
+      $listExpr.flatMap(_.toList).filterNot(_ == primary)
+    }
+  }
+}

--- a/macro-common/src/test/scala-3/org/mockito/internal/MockMethodMetadataTest.scala
+++ b/macro-common/src/test/scala-3/org/mockito/internal/MockMethodMetadataTest.scala
@@ -1,0 +1,50 @@
+package org.mockito.internal
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.reflect.ClassTag
+
+private case class MMT_ValueId(value: Int) extends AnyVal
+
+private trait MMT_MetadataTarget {
+  type Alias = String
+  def byNameAndVarArg(x: => Int, ys: String*): Unit
+  def plainFunction0(f: () => String): String
+  def aliasReturn: Alias
+  def valueId: MMT_ValueId
+}
+
+private trait MMT_ExtraA
+private trait MMT_ExtraB
+private trait MMT_ExtraC
+
+class MockMethodMetadataTest extends AnyWordSpec with Matchers {
+
+  "registerByNameAndVarArgInfo" should {
+    "populate by-name/vararg and return metadata in cache" in {
+      MockMethodMetadata.registerByNameAndVarArgInfo[MMT_MetadataTarget]
+
+      val byNameMethod = classOf[MMT_MetadataTarget].getMethods.find(_.getName == "byNameAndVarArg").get
+      val byNameInfos  = MockMetadataCache.getByName(classOf[MMT_MetadataTarget])
+      byNameInfos should not be empty
+      byNameInfos.get.toMap.get(byNameMethod) shouldBe Some(Set(0, 1))
+      byNameInfos.get.exists(_._1.getName == "plainFunction0") shouldBe false
+
+      val aliasMethod   = classOf[MMT_MetadataTarget].getMethod("aliasReturn")
+      val valueIdMethod = classOf[MMT_MetadataTarget].getMethod("valueId")
+      MockMetadataCache.getReturnType(aliasMethod) shouldBe Some(classOf[String])
+      MockMetadataCache.getReturnsValueClass(valueIdMethod) shouldBe Some(true)
+    }
+  }
+
+  "extraInterfacesImpl" should {
+    "exclude the primary runtime class and return only extras for intersections" in {
+      type Intersection = MMT_ExtraA & MMT_ExtraB & MMT_ExtraC
+      val primary  = summon[ClassTag[Intersection]].runtimeClass
+      val expected = Set(classOf[MMT_ExtraA], classOf[MMT_ExtraB], classOf[MMT_ExtraC]) - primary
+
+      MockMethodMetadata.extraInterfacesImpl[Intersection].toSet shouldBe expected
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a new Scala 3-only `ReflectionUtils` implementation in common that uses compile-time metadata registration (`MockMethodMetadata`) plus runtime cache lookup (`MockMetadataCache`) instead of Scala runtime reflection unavailable in Scala 3.
We also wire registration into Scala 3 `MockCreator`, and implement `DoSomethingCompat` for proper Scala 3 Function0 resolution