### PR TITLE
Enable Scala 3 for macroSub and implement `Captor` and `DefaultValueProviderMacro`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -201,9 +201,11 @@ lazy val macroSub = (project in file("macro"))
   .dependsOn(common)
   .settings(
     commonSettings,
+    crossScalaVersions += scala3Version,
     noPublishingSettings,
     libraryDependencies ++= Dependencies.commonLibraries,
     libraryDependencies ++= Dependencies.scalaReflection.value,
+    libraryDependencies += Dependencies.scalatest % Test,
     publish         := {},
     publishLocal    := {},
     publishArtifact := false

--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,4 @@
 #  As each module gains Scala 3 support, add it to the explicit +<module>/test commands below.
 #  Once all modules support Scala 3, add scala3Version to commonSettings crossScalaVersions
 #  and remove the per-module commands.
-java -Xms512M -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=192m -Dfile.encoding=UTF-8 -jar sbt/sbt-launch.jar -Dsbt.parser.simple=true clean +test +common/test +macroCommon/test 'set every publishTo := Some(Resolver.file("local-repo", file("target/dist")))' '+ publish'
+java -Xms512M -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=192m -Dfile.encoding=UTF-8 -jar sbt/sbt-launch.jar -Dsbt.parser.simple=true clean +test +common/test +macroCommon/test +macroSub/test 'set every publishTo := Some(Resolver.file("local-repo", file("target/dist")))' '+ publish'

--- a/macro/src/main/scala-3/org/mockito/Called.scala
+++ b/macro/src/main/scala-3/org/mockito/Called.scala
@@ -1,0 +1,7 @@
+package org.mockito
+
+/**
+ * Stub so that the shared WhenMacroRuntime (scala/) compiles under Scala 3. WhenMacroRuntime references Called.type in RealMethod.willBe. The full implementation with the by[T]
+ * macro will be added in the upcoming commits.
+ */
+object Called

--- a/macro/src/main/scala-3/org/mockito/Utils.scala
+++ b/macro/src/main/scala-3/org/mockito/Utils.scala
@@ -1,0 +1,26 @@
+package org.mockito
+
+import scala.quoted.*
+
+/**
+ * Shared Scala 3 macro tree utilities used by macro implementations across packages.
+ */
+object Utils {
+
+  /** Find the type of the single constructor parameter of a value class, or abort with a macro error */
+  private[mockito] def findValueClassParamType(using Quotes)(tpe: quotes.reflect.TypeRepr): quotes.reflect.TypeRepr = {
+    import quotes.reflect.*
+    tpe.typeSymbol.primaryConstructor.paramSymss.flatten
+      .collectFirst { case p if p.isTerm => tpe.memberType(p).widen }
+      .getOrElse(report.errorAndAbort(s"Could not find constructor parameter for value class ${tpe.show}"))
+  }
+
+  /** Extract type argument trees from an applied type, or Nil for non-generic types */
+  private[mockito] def typeArgTrees(using Quotes)(tpe: quotes.reflect.TypeRepr): List[quotes.reflect.TypeTree] = {
+    import quotes.reflect.*
+    tpe match {
+      case AppliedType(_, args) => args.map(a => TypeTree.of(using a.asType))
+      case _                    => Nil
+    }
+  }
+}

--- a/macro/src/main/scala-3/org/mockito/captor/Captor.scala
+++ b/macro/src/main/scala-3/org/mockito/captor/Captor.scala
@@ -1,0 +1,74 @@
+package org.mockito.captor
+
+import org.mockito.{ MacroConstants, Utils }
+import scala.quoted.*
+import scala.reflect.ClassTag
+
+/**
+ * Scala 3 version - trait extends shared CaptorBase.
+ */
+trait Captor[T] extends CaptorBase[T]
+
+/** WrapperCaptor for Scala 3 - extends both WrapperCaptorBase and Captor trait */
+class WrapperCaptor[T: ClassTag] extends WrapperCaptorBase[T] with Captor[T]
+
+/** Value class captor: captures the underlying type U and wraps into T */
+class ValueClassCaptor[T, U](underlyingCt: ClassTag[U])(using wrap: U => T) extends Captor[T] {
+  import scala.jdk.CollectionConverters.*
+
+  private val argumentCaptor = org.mockito.ArgumentCaptor.forClass(org.mockito.clazz[U](using underlyingCt))
+
+  override def capture: T      = wrap(argumentCaptor.capture())
+  override def value: T        = wrap(argumentCaptor.getValue)
+  override def values: List[T] = argumentCaptor.getAllValues.asScala.map(wrap).toList
+}
+
+object Captor {
+  given asCapture[T]: Conversion[Captor[T], T] with {
+    def apply(c: Captor[T]): T = c.capture
+  }
+
+  inline given materializeValueClassCaptor[T]: Captor[T] = ${ materializeValueClassCaptorImpl[T] }
+
+  def materializeValueClassCaptorImpl[T: Type](using Quotes): Expr[Captor[T]] = {
+    import quotes.reflect.*
+
+    val tpe        = TypeRepr.of[T]
+    val typeSymbol = tpe.typeSymbol
+
+    val isUserDefinedValueClass = tpe.baseClasses.exists(_.fullName == "scala.AnyVal") &&
+      typeSymbol != Symbol.classSymbol("scala.AnyVal") &&
+      !MacroConstants.isPrimitive(typeSymbol.fullName)
+
+    if (isUserDefinedValueClass) {
+      Utils.findValueClassParamType(tpe).asType match {
+        case '[u] =>
+          Expr.summon[ClassTag[u]] match {
+            case Some(ct) =>
+              '{ new ValueClassCaptor[T, u]($ct)(using ${ constructValueClass[T, u] }) }
+            case None =>
+              report.errorAndAbort(s"No ClassTag available for underlying type ${tpe.show}")
+          }
+      }
+    } else {
+      Expr.summon[ClassTag[T]] match {
+        case Some(ct) =>
+          '{ new WrapperCaptor[T](using $ct) }
+        case None =>
+          report.errorAndAbort(s"No ClassTag available for ${tpe.show}")
+      }
+    }
+  }
+
+  /** Create a function expression that wraps an underlying value into its value class */
+  private def constructValueClass[T: Type, U: Type](using Quotes): Expr[U => T] = {
+    import quotes.reflect.*
+    val tpe            = TypeRepr.of[T]
+    val constructor    = tpe.typeSymbol.primaryConstructor
+    val typeArgTrees   = Utils.typeArgTrees(tpe)
+    val constructorRef = Select(New(TypeIdent(tpe.typeSymbol)), constructor)
+    val applied        = if (typeArgTrees.nonEmpty) TypeApply(constructorRef, typeArgTrees) else constructorRef
+
+    '{ (u: U) => ${ applied.appliedTo('u.asTerm).asExprOf[T] } }
+  }
+}

--- a/macro/src/main/scala-3/org/mockito/matchers/DefaultValueProviderMacro.scala
+++ b/macro/src/main/scala-3/org/mockito/matchers/DefaultValueProviderMacro.scala
@@ -1,0 +1,40 @@
+package org.mockito.matchers
+
+import org.mockito.Utils
+import scala.quoted.*
+
+/**
+ * Scala 3 macro implementation for DefaultValueProvider.
+ */
+trait DefaultValueProviderCompat {
+  inline implicit def default[T]: DefaultValueProvider[T] = ${ DefaultValueProviderMacro.defaultValueProviderImpl[T] }
+}
+
+object DefaultValueProviderMacro {
+  def defaultValueProviderImpl[T: Type](using Quotes): Expr[DefaultValueProvider[T]] = {
+    import quotes.reflect.*
+
+    val tpe        = TypeRepr.of[T]
+    val typeSymbol = tpe.typeSymbol
+
+    val isCaseValueClass = tpe.baseClasses.exists(_.fullName == "scala.AnyVal") &&
+      typeSymbol.flags.is(Flags.Case)
+
+    if (isCaseValueClass) {
+      Utils.findValueClassParamType(tpe).asType match {
+        case '[innerT] =>
+          val innerDefaultExpr = '{ DefaultValueProvider.defaultProvider[innerT].default }
+          val typeArgTrees     = Utils.typeArgTrees(tpe)
+          val constructorRef   = Select(New(TypeIdent(typeSymbol)), typeSymbol.primaryConstructor)
+          val constructorCall  =
+            if (typeArgTrees.nonEmpty)
+              Apply(TypeApply(constructorRef, typeArgTrees), List(innerDefaultExpr.asTerm))
+            else
+              Apply(constructorRef, List(innerDefaultExpr.asTerm))
+          '{ new DefaultValueProvider[T] { override def default: T = ${ constructorCall.asExprOf[T] } } }
+      }
+    } else {
+      '{ DefaultValueProvider.defaultProvider[T] }
+    }
+  }
+}

--- a/macro/src/main/scala/org/mockito/MacroConstants.scala
+++ b/macro/src/main/scala/org/mockito/MacroConstants.scala
@@ -69,4 +69,9 @@ object MacroConstants {
   )
 
   val WasWere: Pattern = "(was|were)".r.pattern
+
+  private val Primitives: Set[String] =
+    Set("scala.Int", "scala.Long", "scala.Double", "scala.Float", "scala.Boolean", "scala.Byte", "scala.Short", "scala.Char", "scala.Unit")
+
+  def isPrimitive(fullName: String): Boolean = Primitives.contains(fullName)
 }

--- a/macro/src/test/scala/org/mockito/MacroSubTest.scala
+++ b/macro/src/test/scala/org/mockito/MacroSubTest.scala
@@ -1,0 +1,48 @@
+package org.mockito
+
+import org.mockito.matchers.DefaultValueProvider
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+/**
+ * Tests that run for ALL Scala versions (Scala 2 and 3).
+ *
+ * Verifies the shared contract of DefaultValueProvider and Captor macro materialisation, using only version-agnostic APIs.
+ */
+private case class MacroShared_UserId(value: Long)   extends AnyVal
+private case class MacroShared_Tagged[T](value: Int) extends AnyVal
+
+class MacroSubTest extends AnyWordSpec with Matchers {
+
+  "DefaultValueProvider" should {
+    "provide the zero-equivalent default for a value class" in {
+      implicitly[DefaultValueProvider[MacroShared_UserId]].default shouldBe MacroShared_UserId(0L)
+    }
+
+    "provide null for String" in {
+      implicitly[DefaultValueProvider[String]].default shouldBe null
+    }
+
+    "provide the zero-equivalent default for a value class with a phantom type parameter" in {
+      implicitly[DefaultValueProvider[MacroShared_Tagged[String]]].default shouldBe MacroShared_Tagged[String](0)
+    }
+  }
+
+  "Captor" should {
+    "materialise for a plain type with no captured values initially" in {
+      implicitly[captor.Captor[Int]].values shouldBe empty
+    }
+
+    "materialise for a value class with no captured values initially" in {
+      implicitly[captor.Captor[MacroShared_UserId]].values shouldBe empty
+    }
+
+    "materialise for a value class with a phantom type parameter with no captured values initially" in {
+      implicitly[captor.Captor[MacroShared_Tagged[String]]].values shouldBe empty
+    }
+
+    "use WrapperCaptor for plain types" in {
+      implicitly[captor.Captor[Int]].getClass.getSimpleName should include("WrapperCaptor")
+    }
+  }
+}


### PR DESCRIPTION
This enables Scala 3 for macroSub module and implements `Captor` and `DefaultValueProviderMacro`
Also, we add cross scala version test for basic verification of these implementations
