### PR TITLE
Add Scala 3 idiomatic API for core module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -181,8 +181,10 @@ lazy val core = (project in file("core"))
     commonSettings,
     publishSettings,
     name := "mockito-scala",
+    crossScalaVersions += scala3Version,
     libraryDependencies ++= Dependencies.commonLibraries,
     libraryDependencies ++= Dependencies.scalaReflection.value,
+    libraryDependencies += Dependencies.scalatest % Test,
     // include the macro classes and resources in the main jar
     Compile / packageBin / mappings ++= (macroSub / Compile / packageBin / mappings).value,
     // include the macro sources in the main source jar

--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,4 @@
 #  As each module gains Scala 3 support, add it to the explicit +<module>/test commands below.
 #  Once all modules support Scala 3, add scala3Version to commonSettings crossScalaVersions
 #  and remove the per-module commands.
-java -Xms512M -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=192m -Dfile.encoding=UTF-8 -jar sbt/sbt-launch.jar -Dsbt.parser.simple=true clean +test +common/test +macroCommon/test +macroSub/test 'set every publishTo := Some(Resolver.file("local-repo", file("target/dist")))' '+ publish'
+java -Xms512M -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=192m -Dfile.encoding=UTF-8 -jar sbt/sbt-launch.jar -Dsbt.parser.simple=true clean +test +common/test +macroCommon/test +macroSub/test +core/test 'set every publishTo := Some(Resolver.file("local-repo", file("target/dist")))' '+ publish'

--- a/core/src/main/scala-3/org/mockito/IdiomaticMockitoBase.scala
+++ b/core/src/main/scala-3/org/mockito/IdiomaticMockitoBase.scala
@@ -1,0 +1,26 @@
+package org.mockito
+
+import scala.quoted.*
+
+/**
+ * Scala 3 version of IdiomaticMockitoBase with inline macro-based operations (stubs).
+ */
+object IdiomaticMockitoBase extends IdiomaticMockitoBaseRuntime {
+  // Macro-based case classes - value is captured from the willBe/mustBe call
+  case class ReturnedBy[T](value: T) {
+    transparent inline def by[S](inline stubbing: S): S =
+      DoSomethingMacro.returnedByMacro[T, S](value, stubbing)
+  }
+
+  case class AnsweredBy[T](valueThunk: () => T) {
+    transparent inline def by[S](inline stubbing: S): S =
+      DoSomethingMacro.answeredByThunkMacro[T, S](valueThunk, stubbing)
+  }
+
+  class ThrownBy[E](value: E) {
+    transparent inline def by[T](inline stubbing: T): T =
+      DoSomethingMacro.thrownByMacro[T, E](value, stubbing)
+  }
+}
+
+trait IdiomaticMockitoBase extends IdiomaticStubbing with PostfixVerifications

--- a/core/src/main/scala-3/org/mockito/IdiomaticStubbing.scala
+++ b/core/src/main/scala-3/org/mockito/IdiomaticStubbing.scala
@@ -1,0 +1,101 @@
+package org.mockito
+
+import org.mockito.WhenMacroRuntime.{ AnswerActions, AnswerPFActions, RealMethod }
+import org.mockito.stubbing.ScalaOngoingStubbing
+import scala.quoted.*
+
+import org.mockito.WhenMacro
+import org.mockito.DoSomethingMacro
+
+/**
+ * Scala 3 version of IdiomaticStubbing with inline macro-based operations (stubs).
+ */
+trait IdiomaticStubbing extends IdiomaticStubbingRuntime {
+  import org.mockito.IdiomaticMockitoBase.*
+
+  val called: Called.type = Called
+
+  extension [T](inline stubbing: T) {
+    transparent inline def shouldReturn: ReturnActions[T] = WhenMacro.shouldReturn[T](stubbing).asInstanceOf[ReturnActions[T]]
+    transparent inline def mustReturn: ReturnActions[T]   = WhenMacro.shouldReturn[T](stubbing).asInstanceOf[ReturnActions[T]]
+    transparent inline def returns: ReturnActions[T]      = WhenMacro.shouldReturn[T](stubbing).asInstanceOf[ReturnActions[T]]
+
+    transparent inline def shouldCall(crm: RealMethod.type): ScalaOngoingStubbing[T] = WhenMacro.shouldCallRealMethod[T](stubbing)(using org.scalactic.Prettifier.default)
+    transparent inline def mustCall(crm: RealMethod.type): ScalaOngoingStubbing[T]   = WhenMacro.shouldCallRealMethod[T](stubbing)(using org.scalactic.Prettifier.default)
+    transparent inline def calls(crm: RealMethod.type): ScalaOngoingStubbing[T]      = WhenMacro.shouldCallRealMethod[T](stubbing)(using org.scalactic.Prettifier.default)
+
+    transparent inline def shouldThrow: ThrowActions[T] = WhenMacro.shouldThrow[T](stubbing).asInstanceOf[ThrowActions[T]]
+    transparent inline def mustThrow: ThrowActions[T]   = WhenMacro.shouldThrow[T](stubbing).asInstanceOf[ThrowActions[T]]
+    transparent inline def throws: ThrowActions[T]      = WhenMacro.shouldThrow[T](stubbing).asInstanceOf[ThrowActions[T]]
+
+    transparent inline def shouldAnswer: AnswerActions[T] = WhenMacro.shouldAnswer[T](stubbing).asInstanceOf[AnswerActions[T]]
+    transparent inline def mustAnswer: AnswerActions[T]   = WhenMacro.shouldAnswer[T](stubbing).asInstanceOf[AnswerActions[T]]
+    transparent inline def answers: AnswerActions[T]      = WhenMacro.shouldAnswer[T](stubbing).asInstanceOf[AnswerActions[T]]
+
+    transparent inline def shouldAnswerPF: AnswerPFActions[T] = WhenMacro.shouldAnswerPF[T](stubbing).asInstanceOf[AnswerPFActions[T]]
+    transparent inline def mustAnswerPF: AnswerPFActions[T]   = WhenMacro.shouldAnswerPF[T](stubbing).asInstanceOf[AnswerPFActions[T]]
+    transparent inline def answersPF: AnswerPFActions[T]      = WhenMacro.shouldAnswerPF[T](stubbing).asInstanceOf[AnswerPFActions[T]]
+
+    transparent inline def isLenient(): Unit = WhenMacro.isLenient[T](stubbing)(using org.scalactic.Prettifier.default)
+
+    transparent inline def shouldDoNothing(): Unit = DoSomethingMacro.doesNothing(stubbing)
+    transparent inline def mustDoNothing(): Unit   = DoSomethingMacro.doesNothing(stubbing)
+    transparent inline def doesNothing(): Unit     = DoSomethingMacro.doesNothing(stubbing)
+  }
+
+  extension [R](v: R) {
+    def willBe(r: Returned.type): ReturnedBy[R] = ReturnedBy[R](v)
+  }
+
+  extension [R](inline v: R) {
+    transparent inline def willBe(a: Answered.type): AnsweredBy[R] = AnsweredBy[R](() => v)
+  }
+
+  extension [R](v: () => R) {
+    def willBe(a: Answered.type): AnsweredBy[() => R] = AnsweredBy[() => R](() => v)
+  }
+
+  extension [P0, R](v: P0 => R) {
+    def willBe(a: Answered.type): AnsweredBy[P0 => R] = AnsweredBy[P0 => R](() => v)
+  }
+
+  extension [P0, P1, R](v: (P0, P1) => R) {
+    def willBe(a: Answered.type): AnsweredBy[(P0, P1) => R] = AnsweredBy[(P0, P1) => R](() => v)
+  }
+
+  extension [P0, P1, P2, R](v: (P0, P1, P2) => R) {
+    def willBe(a: Answered.type): AnsweredBy[(P0, P1, P2) => R] = AnsweredBy[(P0, P1, P2) => R](() => v)
+  }
+
+  extension [P0, P1, P2, P3, R](v: (P0, P1, P2, P3) => R) {
+    def willBe(a: Answered.type): AnsweredBy[(P0, P1, P2, P3) => R] = AnsweredBy[(P0, P1, P2, P3) => R](() => v)
+  }
+
+  extension [P0, P1, P2, P3, P4, R](v: (P0, P1, P2, P3, P4) => R) {
+    def willBe(a: Answered.type): AnsweredBy[(P0, P1, P2, P3, P4) => R] = AnsweredBy[(P0, P1, P2, P3, P4) => R](() => v)
+  }
+
+  extension [P0, P1, P2, P3, P4, P5, R](v: (P0, P1, P2, P3, P4, P5) => R) {
+    def willBe(a: Answered.type): AnsweredBy[(P0, P1, P2, P3, P4, P5) => R] = AnsweredBy[(P0, P1, P2, P3, P4, P5) => R](() => v)
+  }
+
+  extension [P0, P1, P2, P3, P4, P5, P6, R](v: (P0, P1, P2, P3, P4, P5, P6) => R) {
+    def willBe(a: Answered.type): AnsweredBy[(P0, P1, P2, P3, P4, P5, P6) => R] = AnsweredBy[(P0, P1, P2, P3, P4, P5, P6) => R](() => v)
+  }
+
+  extension [P0, P1, P2, P3, P4, P5, P6, P7, R](v: (P0, P1, P2, P3, P4, P5, P6, P7) => R) {
+    def willBe(a: Answered.type): AnsweredBy[(P0, P1, P2, P3, P4, P5, P6, P7) => R] = AnsweredBy[(P0, P1, P2, P3, P4, P5, P6, P7) => R](() => v)
+  }
+
+  extension [P0, P1, P2, P3, P4, P5, P6, P7, P8, R](v: (P0, P1, P2, P3, P4, P5, P6, P7, P8) => R) {
+    def willBe(a: Answered.type): AnsweredBy[(P0, P1, P2, P3, P4, P5, P6, P7, P8) => R] = AnsweredBy[(P0, P1, P2, P3, P4, P5, P6, P7, P8) => R](() => v)
+  }
+
+  extension [P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, R](v: (P0, P1, P2, P3, P4, P5, P6, P7, P8, P9) => R) {
+    def willBe(a: Answered.type): AnsweredBy[(P0, P1, P2, P3, P4, P5, P6, P7, P8, P9) => R] = AnsweredBy[(P0, P1, P2, P3, P4, P5, P6, P7, P8, P9) => R](() => v)
+  }
+
+  extension [E](v: E) {
+    def willBe(thrown: Thrown.type): ThrownBy[E] = new ThrownBy[E](v)
+  }
+}

--- a/core/src/main/scala-3/org/mockito/PostfixVerifications.scala
+++ b/core/src/main/scala-3/org/mockito/PostfixVerifications.scala
@@ -1,0 +1,27 @@
+package org.mockito
+
+import scala.quoted.*
+
+/**
+ * Scala 3 version of PostfixVerifications with inline macro-based operations (stubs).
+ */
+trait PostfixVerifications extends PostfixVerificationsRuntime {
+
+  import org.mockito.IdiomaticMockitoBaseRuntime.*
+
+  extension [T](inline stubbing: T) {
+    transparent inline def was(called: Called.type)(using order: VerifyOrder): Verification =
+      ${ VerifyMacro.wasMacroImpl[T, Verification]('stubbing, 'called, 'order) }
+
+    transparent inline def wasNever(called: Called.type)(using order: VerifyOrder): Verification =
+      ${ VerifyMacro.wasNeverMacroImpl[T, Verification]('stubbing, 'called, 'order) }
+
+    transparent inline def wasNever(inline called: CalledAgain)(using $ev: T <:< AnyRef): Verification =
+      ${ VerifyMacro.wasNeverCalledAgainMacroImpl[T, Verification]('stubbing, 'called) }
+
+    transparent inline def wasCalled(called: ScalaVerificationMode)(using order: VerifyOrder): Verification =
+      ${ VerifyMacro.wasCalledMacroImpl[T, Verification]('stubbing, 'called, 'order) }
+  }
+
+  def InOrder(mocks: AnyRef*)(verifications: VerifyInOrder => Verification): Verification = verifications(VerifyInOrder(mocks))
+}

--- a/core/src/main/scala-3/org/mockito/PrefixExpectations.scala
+++ b/core/src/main/scala-3/org/mockito/PrefixExpectations.scala
@@ -1,0 +1,86 @@
+package org.mockito
+
+import scala.quoted.*
+
+/**
+ * Scala 3 version of PrefixExpectations with inline macro-based operations (stubs).
+ */
+trait PrefixExpectations extends PrefixExpectationsRuntime {
+  import org.mockito.IdiomaticMockitoBase.*
+
+  class ExpectationOps(val mode: ScalaVerificationMode) {
+
+    /**
+     * Use `calls to` to describe expectations about a _stubbed method call_.
+     *
+     * If you need to describe expectations about a mocked object itself (i.e. zero interactions), use `calls on`.
+     */
+    transparent inline def to[T](inline stubbedMethodCall: T)(using inline order: VerifyOrder): Verification =
+      ExpectMacro.callsTo[Verification](stubbedMethodCall, mode)(order)
+  }
+
+  trait ExpectNoCallsOnMacros {
+    transparent inline def on[T <: AnyRef](inline mock: T): Verification =
+      ExpectMacro.callsOn[Verification](mock)
+  }
+
+  class ExpectNoMoreCallsOnMacros(val ignoringStubs: Boolean) {
+    transparent inline def on[T <: AnyRef](inline mock: T): Verification =
+      ${ ExpectMacro.callsOnNoMoreImpl[Verification]('mock, '{ this.ignoringStubs }) }
+  }
+
+  // Define expect object to return ExpectationOps with macro methods
+  object expect {
+    def a(callWord: CallWord.type): ExpectationOps       = new ExpectationOps(Times(1))
+    def one(callWord: CallWord.type): ExpectationOps     = new ExpectationOps(Times(1))
+    def two(callsWord: CallsWord.type): ExpectationOps   = new ExpectationOps(Times(2))
+    def three(callsWord: CallsWord.type): ExpectationOps = new ExpectationOps(Times(3))
+    def four(callsWord: CallsWord.type): ExpectationOps  = new ExpectationOps(Times(4))
+    def five(callsWord: CallsWord.type): ExpectationOps  = new ExpectationOps(Times(5))
+    def six(callsWord: CallsWord.type): ExpectationOps   = new ExpectationOps(Times(6))
+    def seven(callsWord: CallsWord.type): ExpectationOps = new ExpectationOps(Times(7))
+    def eight(callsWord: CallsWord.type): ExpectationOps = new ExpectationOps(Times(8))
+    def nine(callsWord: CallsWord.type): ExpectationOps  = new ExpectationOps(Times(9))
+    def ten(callsWord: CallsWord.type): ExpectationOps   = new ExpectationOps(Times(10))
+
+    def exactly(calls: Calls): ExpectationOps = new ExpectationOps(Times(calls.times))
+
+    def atLeastOne(callWord: CallWord.type): ExpectationOps     = new ExpectationOps(AtLeast(1))
+    def atLeastTwo(callsWord: CallsWord.type): ExpectationOps   = new ExpectationOps(AtLeast(2))
+    def atLeastThree(callsWord: CallsWord.type): ExpectationOps = new ExpectationOps(AtLeast(3))
+    def atLeastFour(callsWord: CallsWord.type): ExpectationOps  = new ExpectationOps(AtLeast(4))
+    def atLeastFive(callsWord: CallsWord.type): ExpectationOps  = new ExpectationOps(AtLeast(5))
+    def atLeastSix(callsWord: CallsWord.type): ExpectationOps   = new ExpectationOps(AtLeast(6))
+    def atLeastSeven(callsWord: CallsWord.type): ExpectationOps = new ExpectationOps(AtLeast(7))
+    def atLeastEight(callsWord: CallsWord.type): ExpectationOps = new ExpectationOps(AtLeast(8))
+    def atLeastNine(callsWord: CallsWord.type): ExpectationOps  = new ExpectationOps(AtLeast(9))
+    def atLeastTen(callsWord: CallsWord.type): ExpectationOps   = new ExpectationOps(AtLeast(10))
+
+    def atLeast(calls: Calls): ExpectationOps = new ExpectationOps(AtLeast(calls.times))
+
+    def atMostOne(callWord: CallWord.type): ExpectationOps     = new ExpectationOps(AtMost(1))
+    def atMostTwo(callsWord: CallsWord.type): ExpectationOps   = new ExpectationOps(AtMost(2))
+    def atMostThree(callsWord: CallsWord.type): ExpectationOps = new ExpectationOps(AtMost(3))
+    def atMostFour(callsWord: CallsWord.type): ExpectationOps  = new ExpectationOps(AtMost(4))
+    def atMostFive(callsWord: CallsWord.type): ExpectationOps  = new ExpectationOps(AtMost(5))
+    def atMostSix(callsWord: CallsWord.type): ExpectationOps   = new ExpectationOps(AtMost(6))
+    def atMostSeven(callsWord: CallsWord.type): ExpectationOps = new ExpectationOps(AtMost(7))
+    def atMostEight(callsWord: CallsWord.type): ExpectationOps = new ExpectationOps(AtMost(8))
+    def atMostNine(callsWord: CallsWord.type): ExpectationOps  = new ExpectationOps(AtMost(9))
+    def atMostTen(callsWord: CallsWord.type): ExpectationOps   = new ExpectationOps(AtMost(10))
+
+    def atMost(calls: Calls): ExpectationOps = new ExpectationOps(AtMost(calls.times))
+
+    def no(callsWord: CallsWord.type): ExpectationOps with ExpectNoCallsOnMacros =
+      new ExpectationOps(VerifyMacroRuntime.Never) with ExpectNoCallsOnMacros {}
+
+    transparent inline def noMore(inline callsWord: CallsWord.type): ExpectNoMoreCallsOnMacros =
+      ${ ExpectMacro.noMoreMacro[ExpectNoMoreCallsOnMacros]('callsWord) }
+
+    def only(callWord: CallWord.type): ExpectationOps = new ExpectationOps(OnlyOn)
+  }
+
+  def expect(mode: ScalaVerificationMode): ExpectationOps = new ExpectationOps(mode)
+
+  def InOrder(mocks: AnyRef*)(verifications: VerifyInOrder => Verification): Verification = verifications(VerifyInOrder(mocks))
+}

--- a/core/src/main/scala/org/mockito/IdiomaticMockitoBaseRuntime.scala
+++ b/core/src/main/scala/org/mockito/IdiomaticMockitoBaseRuntime.scala
@@ -115,7 +115,7 @@ object IdiomaticMockitoBaseRuntime {
   }
 
   class ThrowActions[T](os: ScalaFirstStubbing[T]) {
-    def apply[E <: Throwable](e: E*): ScalaOngoingStubbing[T] = os thenThrow (e*)
+    def apply[E <: Throwable](e: E*): ScalaOngoingStubbing[T] = os.thenThrow(e*)
   }
 
   // types for postfix verifications

--- a/core/src/test/scala/org/mockito/IdiomaticApiTest.scala
+++ b/core/src/test/scala/org/mockito/IdiomaticApiTest.scala
@@ -1,0 +1,131 @@
+package org.mockito
+
+import org.mockito.exceptions.verification.WantedButNotInvoked
+import org.scalactic.Prettifier
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+// ── test models (package-level to avoid path-dependent type issues with macros) ──
+
+private[mockito] trait IA_Foo {
+  def bar: String
+  def baz(x: Int): String
+  def unit(): Unit
+}
+
+/**
+ * Cross-version unit tests for [[IdiomaticStubbing]] and [[PostfixVerifications]].
+ *
+ * Exercises the idiomatic stubbing and verification DSL (returns, answers, throws, willBe, was called, etc.) via [[IdiomaticMockito]], which picks up the version-specific
+ * implementations at compile time.
+ */
+class IdiomaticApiTest extends AnyWordSpec with Matchers with IdiomaticMockito with ArgumentMatchersSugar {
+
+  implicit val prettifier: Prettifier = Prettifier.default
+
+  "IdiomaticStubbing" should {
+
+    "stub a return value with returns" in {
+      val m = mock[IA_Foo]
+      m.bar returns "mocked"
+      m.bar shouldBe "mocked"
+    }
+
+    "stub a return value with shouldReturn" in {
+      val m = mock[IA_Foo]
+      m.bar shouldReturn "mocked"
+      m.bar shouldBe "mocked"
+    }
+
+    "stub multiple return values with returns andThen" in {
+      val m = mock[IA_Foo]
+      m.bar returns "first" andThen "second"
+      m.bar shouldBe "first"
+      m.bar shouldBe "second"
+    }
+
+    "stub a computed answer with answers" in {
+      val m     = mock[IA_Foo]
+      var count = 0
+      m.bar answers { count += 1; count.toString }
+      m.bar shouldBe "1"
+      m.bar shouldBe "2"
+    }
+
+    "stub a one-arg answer with answers" in {
+      val m = mock[IA_Foo]
+      m.baz(*) answers ((x: Int) => s"got $x")
+      m.baz(42) shouldBe "got 42"
+    }
+
+    "stub an exception to be thrown with throws" in {
+      val m = mock[IA_Foo]
+      m.bar throws new IllegalArgumentException("boom")
+      an[IllegalArgumentException] shouldBe thrownBy(m.bar)
+    }
+
+    "stub doesNothing for unit method" in {
+      val m = mock[IA_Foo]
+      m.unit().doesNothing()
+      noException shouldBe thrownBy(m.unit())
+    }
+
+    "stub a return value with willBe returned by" in {
+      val m = mock[IA_Foo]
+      "mocked" willBe returned by m.bar
+      m.bar shouldBe "mocked"
+    }
+
+    "stub a computed answer with willBe answered by" in {
+      val m                   = mock[IA_Foo]
+      var count               = 0
+      val thunk: () => String = () => { count += 1; count.toString }
+      thunk willBe answered by m.bar
+      m.bar shouldBe "1"
+      m.bar shouldBe "2"
+    }
+
+    "stub an exception with willBe thrown by" in {
+      val m = mock[IA_Foo]
+      new IllegalArgumentException("boom") willBe thrown by m.bar
+      an[IllegalArgumentException] shouldBe thrownBy(m.bar)
+    }
+  }
+
+  "PostfixVerifications" should {
+
+    "verify a method was called" in {
+      val m = mock[IA_Foo]
+      m.bar returns "x"
+      m.bar
+      m.bar was called
+    }
+
+    "verify a method was never called" in {
+      val m = mock[IA_Foo]
+      m.bar wasNever called
+    }
+
+    "verify a method was called once" in {
+      val m = mock[IA_Foo]
+      m.bar returns "x"
+      m.bar
+      m.bar wasCalled once
+    }
+
+    "verify a method was called twice" in {
+      val m = mock[IA_Foo]
+      m.bar returns "x"
+      m.bar
+      m.bar
+      m.bar wasCalled twice
+    }
+
+    "fail verification when expected call was not made" in {
+      val m = mock[IA_Foo]
+      a[WantedButNotInvoked] shouldBe thrownBy {
+        m.bar was called
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds Scala 3 to core module - mostly wiring previously added macro implementations. 
Plus, new core module isolated tests (covering all Scala versions). 