### PR TITLE
Add Scala 3 support for specs2 module + enabled Scala 3 globally

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ lazy val commonSettings =
   Seq(
     organization := "org.mockito",
     // Load version from the file so that Gradle/Shipkit and SBT use the same version
-    crossScalaVersions := Seq(currentScalaVersion, "2.12.21"),
+    crossScalaVersions := Seq(currentScalaVersion, "2.12.21", scala3Version),
     scalafmtOnCompile  := true,
     scalacOptions ++= {
       val common = Seq(
@@ -116,7 +116,6 @@ lazy val scalatest = (project in file("scalatest"))
     name := "mockito-scala-scalatest",
     commonSettings,
     publishSettings,
-    crossScalaVersions += scala3Version,
     libraryDependencies += Dependencies.scalatest % "provided"
   )
 
@@ -139,7 +138,6 @@ lazy val cats = (project in file("cats"))
     name := "mockito-scala-cats",
     commonSettings,
     publishSettings,
-    crossScalaVersions += scala3Version,
     libraryDependencies ++= Seq(
       Dependencies.cats,
       Dependencies.catsLaws            % "test",
@@ -156,7 +154,6 @@ lazy val scalaz = (project in file("scalaz"))
     name := "mockito-scala-scalaz",
     commonSettings,
     publishSettings,
-    crossScalaVersions += scala3Version,
     libraryDependencies ++= Seq(
       Dependencies.scalaz,
       Dependencies.scalatest % "test"
@@ -168,7 +165,6 @@ lazy val common = (project in file("common"))
   .settings(
     commonSettings,
     noPublishingSettings,
-    crossScalaVersions += scala3Version,
     libraryDependencies ++= Dependencies.commonLibraries ++
       Dependencies.scalaReflection.value ++ Seq(
         Dependencies.catsLaws   % "test",
@@ -184,7 +180,6 @@ lazy val core = (project in file("core"))
     commonSettings,
     publishSettings,
     name := "mockito-scala",
-    crossScalaVersions += scala3Version,
     libraryDependencies ++= Dependencies.commonLibraries,
     libraryDependencies ++= Dependencies.scalaReflection.value,
     libraryDependencies += Dependencies.scalatest % Test,
@@ -206,7 +201,6 @@ lazy val macroSub = (project in file("macro"))
   .dependsOn(common)
   .settings(
     commonSettings,
-    crossScalaVersions += scala3Version,
     noPublishingSettings,
     libraryDependencies ++= Dependencies.commonLibraries,
     libraryDependencies ++= Dependencies.scalaReflection.value,
@@ -220,9 +214,6 @@ lazy val macroCommon = (project in file("macro-common"))
   .settings(
     commonSettings,
     noPublishingSettings,
-    // TODO: Scala 3 is being enabled module-by-module. Once all modules have scala-3/ sources,
-    //  move scala3Version to the global crossScalaVersions in commonSettings and remove per-module overrides.
-    crossScalaVersions += scala3Version,
     libraryDependencies ++= Dependencies.scalaReflection.value,
     libraryDependencies += Dependencies.scalatest % Test,
     publish         := {},
@@ -232,4 +223,4 @@ lazy val macroCommon = (project in file("macro-common"))
 
 lazy val root = (project in file("."))
   .settings(noPublishingSettings, noCrossBuildSettings)
-  .aggregate(common, core, scalatest, specs2, cats, scalaz)
+  .aggregate(macroCommon, macroSub, common, core, scalatest, specs2, cats, scalaz)

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,2 @@
 #!/usr/bin/env bash
-# TODO: Scala 3 modules are not all in root aggregate, so +test does not cross-build every module for 3.3.7.
-#  As each module gains Scala 3 support, add it to the explicit +<module>/test commands below.
-#  Once all modules support Scala 3, add scala3Version to commonSettings crossScalaVersions
-#  and remove the per-module commands.
-java -Xms512M -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=192m -Dfile.encoding=UTF-8 -jar sbt/sbt-launch.jar -Dsbt.parser.simple=true clean +test +common/test +macroCommon/test +macroSub/test +core/test +scalatest/test +cats/test +scalaz/test 'set every publishTo := Some(Resolver.file("local-repo", file("target/dist")))' '+ publish'
+java -Xms512M -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=192m -Dfile.encoding=UTF-8 -jar sbt/sbt-launch.jar -Dsbt.parser.simple=true clean +test 'set every publishTo := Some(Resolver.file("local-repo", file("target/dist")))' '+ publish'

--- a/macro/src/main/scala-3/org/mockito/Specs2VerifyMacro.scala
+++ b/macro/src/main/scala-3/org/mockito/Specs2VerifyMacro.scala
@@ -1,0 +1,214 @@
+package org.mockito
+
+import org.mockito.MacroConstants.WordsToNumbers
+import org.mockito.Utils.{ buildVerifiedObj, callMethodInScope, transformArgsForApply, wrapInVerification }
+import org.mockito.verification.VerificationMode
+
+import scala.quoted.*
+
+object Specs2VerifyMacro {
+  private val Specs2DslNames = Set("one", "two", "three", "no", "exactly", "atLeast", "atMost", "times", "noCallsTo", "noMoreCallsTo")
+
+  private case class Times(times: Int) extends ScalaVerificationMode {
+    override def verificationMode: VerificationMode = Mockito.times(times)
+  }
+  private case class AtLeast(times: Int) extends ScalaVerificationMode {
+    override def verificationMode: VerificationMode = Mockito.atLeast(times)
+  }
+  private case class AtMost(times: Int) extends ScalaVerificationMode {
+    override def verificationMode: VerificationMode = Mockito.atMost(times)
+  }
+
+  inline def wasMacro[T, R](inline calls: T)(using inline order: VerifyOrder): R =
+    ${ wasMacroImpl[T, R]('calls, 'order) }
+
+  inline def gotMacro[T, R](inline calls: T)(using inline order: VerifyOrder): R =
+    ${ gotMacroImpl[T, R]('calls, 'order) }
+
+  private def wasMacroImpl[T: Type, R: Type](calls: Expr[T], order: Expr[VerifyOrder])(using Quotes): Expr[R] =
+    import quotes.reflect.*
+    transformMaybeVerification(calls.asTerm, order.asTerm).asExprOf[R]
+
+  private def gotMacroImpl[T: Type, R: Type](calls: Expr[T], order: Expr[VerifyOrder])(using Quotes): Expr[R] = {
+    import quotes.reflect.*
+
+    def collectTerms(term: Term): List[Term] = term match {
+      case Inlined(_, _, body) => collectTerms(body)
+      case Block(stats, expr)  => stats.collect { case t: Term => t } ++ collectTerms(expr)
+      case other               => List(other)
+    }
+
+    val terms   = collectTerms(calls.asTerm)
+    val first   = transformMaybeVerification(terms.head, order.asTerm)
+    val chained = terms.tail.foldLeft(first) { (acc, next) =>
+      callMethodInScope("combineVerifications", List(acc, transformMaybeVerification(next, order.asTerm)))
+    }
+    chained.asExprOf[R]
+  }
+
+  private def transformMaybeVerification(using Quotes)(term: quotes.reflect.Term, order: quotes.reflect.Term): quotes.reflect.Term =
+    if isAlreadyVerification(term) then term
+    else transformSpecs2Verification(term, order).getOrElse(term)
+
+  private def transformSpecs2Verification(using
+      Quotes
+  )(
+      term: quotes.reflect.Term,
+      order: quotes.reflect.Term
+  ): Option[quotes.reflect.Term] = {
+    import quotes.reflect.*
+
+    def strip(t: Term): Term = t match {
+      case Inlined(_, _, body) => strip(body)
+      case Block(Nil, expr)    => strip(expr)
+      case other               => other
+    }
+
+    def buildMode(name: String, times: Term): Term =
+      name.toLowerCase match {
+        case "exactly" => '{ Times(${ times.asExprOf[Int] }) }.asTerm
+        case "atleast" => '{ AtLeast(${ times.asExprOf[Int] }) }.asTerm
+        case "atmost"  => '{ AtMost(${ times.asExprOf[Int] }) }.asTerm
+      }
+
+    def extractModeAndMock(t: Term): Option[(Term, Term)] = strip(t) match {
+      case Inlined(_, _, body) =>
+        extractModeAndMock(body)
+
+      case Block(_, expr) =>
+        extractModeAndMock(expr)
+
+      case Typed(expr, _) =>
+        extractModeAndMock(expr)
+
+      case Apply(TypeApply(Select(_, method), _), List(obj)) if WordsToNumbers.contains(method) =>
+        Some((obj, buildMode("exactly", Literal(IntConstant(WordsToNumbers(method))))))
+
+      case Apply(Select(_, method), List(obj)) if WordsToNumbers.contains(method) =>
+        Some((obj, buildMode("exactly", Literal(IntConstant(WordsToNumbers(method))))))
+
+      case Apply(Apply(TypeApply(Select(_, method), _), List(times)), List(obj)) if Set("exactly", "atLeast", "atMost").contains(method) =>
+        Some((obj, buildMode(method, times)))
+
+      case Apply(Apply(Select(_, method), List(times)), List(obj)) if Set("exactly", "atLeast", "atMost").contains(method) =>
+        Some((obj, buildMode(method, times)))
+
+      case Apply(TypeApply(Select(Apply(TypeApply(Select(_, "Specs2IntOps"), _), List(times)), "times"), _), List(obj)) =>
+        Some((obj, buildMode("exactly", times)))
+
+      case Apply(Select(Apply(TypeApply(Select(_, "Specs2IntOps"), _), List(times)), "times"), List(obj)) =>
+        Some((obj, buildMode("exactly", times)))
+
+      case Apply(fun, _) =>
+        extractModeAndMock(fun)
+
+      case TypeApply(fun, _) =>
+        extractModeAndMock(fun)
+
+      case _ => None
+    }
+
+    def zeroInteractions(obj: Term): Term = {
+      val mockitoSugar = Symbol.requiredModule("org.mockito.MockitoSugar")
+      wrapInVerification(Apply(Select.unique(Ref(mockitoSugar), "verifyZeroInteractions"), List(obj)))
+    }
+
+    def noMoreInteractions(obj: Term): Term = {
+      val mockitoSugar = Symbol.requiredModule("org.mockito.MockitoSugar")
+      wrapInVerification(Apply(Select.unique(Ref(mockitoSugar), "verifyNoMoreInteractions"), List(obj)))
+    }
+
+    def transformMethodCall(invocation: Term, hoisted: scala.collection.mutable.ListBuffer[Statement]): Term = invocation match {
+      case Apply(select @ Select(objExpr, _), args) =>
+        extractModeAndMock(objExpr) match {
+          case Some((obj, mode)) =>
+            val transformedArgs = transformArgsForApply(select, args, hoisted)
+            Apply(Select(buildVerifiedObj(obj, order, mode), select.symbol), transformedArgs)
+          case None =>
+            val transformedArgs = transformArgsForApply(select, args, hoisted)
+            Apply(transformMethodCall(select, hoisted), transformedArgs)
+        }
+
+      case Apply(TypeApply(select @ Select(objExpr, _), targs), args) =>
+        extractModeAndMock(objExpr) match {
+          case Some((obj, mode)) =>
+            val transformedArgs = transformArgsForApply(TypeApply(select, targs), args, hoisted)
+            Apply(TypeApply(Select(buildVerifiedObj(obj, order, mode), select.symbol), targs), transformedArgs)
+          case None =>
+            val transformedArgs = transformArgsForApply(TypeApply(select, targs), args, hoisted)
+            Apply(transformMethodCall(TypeApply(select, targs), hoisted), transformedArgs)
+        }
+
+      case select @ Select(objExpr, _) =>
+        extractModeAndMock(objExpr)
+          .map { case (obj, mode) =>
+            Select(buildVerifiedObj(obj, order, mode), select.symbol)
+          }
+          .getOrElse(select)
+
+      case TypeApply(select @ Select(objExpr, _), targs) =>
+        extractModeAndMock(objExpr)
+          .map { case (obj, mode) =>
+            TypeApply(Select(buildVerifiedObj(obj, order, mode), select.symbol), targs)
+          }
+          .getOrElse(TypeApply(select, targs))
+
+      case Apply(fun, args) =>
+        val transformedArgs = transformArgsForApply(fun, args, hoisted)
+        Apply(transformMethodCall(fun, hoisted), transformedArgs)
+
+      case Inlined(_, _, body) =>
+        transformMethodCall(body, hoisted)
+
+      case Block(stats, expr) =>
+        val transformed = transformMethodCall(expr, hoisted)
+        if stats.nonEmpty then Block(stats, transformed) else transformed
+
+      case other =>
+        other
+    }
+
+    strip(term) match {
+      case Apply(TypeApply(Select(_, "noCallsTo"), _), List(obj)) =>
+        Some(zeroInteractions(obj))
+      case Apply(Select(_, "noCallsTo"), List(obj)) =>
+        Some(zeroInteractions(obj))
+      case Apply(TypeApply(Select(_, "noMoreCallsTo"), _), List(obj)) =>
+        Some(noMoreInteractions(obj))
+      case Apply(Select(_, "noMoreCallsTo"), List(obj)) =>
+        Some(noMoreInteractions(obj))
+      case invocation =>
+        val hoisted     = scala.collection.mutable.ListBuffer.empty[Statement]
+        val transformed = transformMethodCall(invocation, hoisted)
+        if transformed == invocation && !containsSpecs2Dsl(invocation) then None
+        else Some(if hoisted.nonEmpty then Block(hoisted.toList, wrapInVerification(transformed)) else wrapInVerification(transformed))
+    }
+  }
+
+  private def isAlreadyVerification(using Quotes)(term: quotes.reflect.Term): Boolean = {
+    import quotes.reflect.*
+    term match {
+      case Inlined(_, _, body)                                 => isAlreadyVerification(body)
+      case Block(_, expr)                                      => isAlreadyVerification(expr)
+      case Apply(Select(_, name), _) if name == "verification" => true
+      case Apply(Ident(name), _) if name == "verification"     => true
+      case _                                                   => false
+    }
+  }
+
+  private def containsSpecs2Dsl(using Quotes)(term: quotes.reflect.Term): Boolean = {
+    import quotes.reflect.*
+
+    def loop(t: Term): Boolean = t match {
+      case Inlined(_, _, body) => loop(body)
+      case Block(stats, expr)  => stats.collect { case tt: Term => tt }.exists(loop) || loop(expr)
+      case Apply(fun, args)    => loop(fun) || args.exists(loop)
+      case TypeApply(fun, _)   => loop(fun)
+      case Select(qual, name)  => Specs2DslNames.contains(name) || loop(qual)
+      case _ => false
+    }
+
+    loop(term)
+  }
+
+}

--- a/macro/src/main/scala-3/org/mockito/Utils.scala
+++ b/macro/src/main/scala-3/org/mockito/Utils.scala
@@ -379,14 +379,13 @@ object Utils {
   }
 
   /**
-   * Walk the splice-owner chain (and each class's companion module) to find a method named `"verification"`. Returns `(ownerSymbol, methodSymbol, useThis)` where `useThis=true`
-   * means the owner is an enclosing class (generate `This(owner).verification(...)`) and `useThis=false` means the owner is a companion module (generate
-   * `Ref(owner).verification(...)`).
+   * Walk the splice-owner chain (and each class's companion module) to find a method with the given name. Returns `(ownerSymbol, methodSymbol, useThis)` where `useThis=true` means
+   * the owner is an enclosing class (generate `This(owner).method(...)`) and `useThis=false` means the owner is a companion module (generate `Ref(owner).method(...)`).
    *
-   * Checking companion modules is needed because in Scala 2 `q"verification(...)"` resolves naturally through scoping (which includes companion objects), while in Scala 3 the
-   * macro builds the AST explicitly and must search for it manually.
+   * Checking companion modules is needed because in Scala 2 quasiquotes resolve through scoping (which includes companion objects), while in Scala 3 the macro builds the AST
+   * explicitly and must search for it manually.
    */
-  private[mockito] def findVerificationSymbol(using Quotes): Option[(quotes.reflect.Symbol, quotes.reflect.Symbol, Boolean)] = {
+  private[mockito] def findMethodInScope(using Quotes)(methodName: String): Option[(quotes.reflect.Symbol, quotes.reflect.Symbol, Boolean)] = {
     import quotes.reflect.*
     Iterator
       .iterate(Symbol.spliceOwner)(_.owner)
@@ -394,7 +393,7 @@ object Utils {
       .flatMap { current =>
         val fromSelf =
           try {
-            val methods = current.methodMembers.filter(_.name == "verification")
+            val methods = current.methodMembers.filter(_.name == methodName)
             if (methods.nonEmpty) Some((current, methods.head, true)) else None
           } catch { case _: Exception => None }
         fromSelf.orElse {
@@ -404,7 +403,7 @@ object Utils {
               val companion = current.companionModule
               if (companion == Symbol.noSymbol) None
               else {
-                val companionMethods = companion.methodMembers.filter(_.name == "verification")
+                val companionMethods = companion.methodMembers.filter(_.name == methodName)
                 if (companionMethods.nonEmpty) Some((companion, companionMethods.head, false)) else None
               }
             } catch { case _: Exception => None }
@@ -413,18 +412,34 @@ object Utils {
       .nextOption()
   }
 
-  /**
-   * Wrap a verification call tree in the `verification(...)` method found by [[findVerificationSymbol]]. Uses `This(owner).verification(call)` for enclosing-class owners and
-   * `Ref(owner).verification(call)` for companion-module owners.
-   */
-  private[mockito] def wrapInVerification(using Quotes)(call: quotes.reflect.Term): quotes.reflect.Term = {
+  private[mockito] def findVerificationSymbol(using Quotes): Option[(quotes.reflect.Symbol, quotes.reflect.Symbol, Boolean)] =
+    findMethodInScope("verification")
+
+  /** Find a method by name in the enclosing scope and apply it to the given arguments. Aborts compilation if the method is not found. */
+  private[mockito] def callMethodInScope(using Quotes)(methodName: String, args: List[quotes.reflect.Term]): quotes.reflect.Term = {
     import quotes.reflect.*
-    findVerificationSymbol match {
+    findMethodInScope(methodName) match {
       case Some((owner, method, useThis)) =>
         val receiver = if (useThis) This(owner) else Ref(owner)
-        Apply(Select(receiver, method), List(call))
+        Apply(Select(receiver, method), args)
       case None =>
-        report.errorAndAbort(s"Could not find 'verification' method in scope. Searched from: ${Symbol.spliceOwner.fullName}")
+        report.errorAndAbort(s"Could not find '$methodName' method in scope. Searched from: ${Symbol.spliceOwner.fullName}")
     }
+  }
+
+  /** Wrap a verification call tree in the `verification(...)` method found in the enclosing scope. */
+  private[mockito] def wrapInVerification(using Quotes)(call: quotes.reflect.Term): quotes.reflect.Term =
+    callMethodInScope("verification", List(call))
+
+  /** Build `order.verifyWithMode[ObjType](obj, mode)` — replaces the mock object with a verifying proxy. */
+  private[mockito] def buildVerifiedObj(using
+      Quotes
+  )(obj: quotes.reflect.Term, order: quotes.reflect.Term, mode: quotes.reflect.Term): quotes.reflect.Term = {
+    import quotes.reflect.*
+    val objType = obj.tpe.widen.asType
+    Apply(
+      TypeApply(Select.unique(order, "verifyWithMode"), List(TypeTree.of(using objType))),
+      List(obj, mode)
+    )
   }
 }

--- a/macro/src/main/scala-3/org/mockito/VerifyMacro.scala
+++ b/macro/src/main/scala-3/org/mockito/VerifyMacro.scala
@@ -79,16 +79,6 @@ object VerifyMacro {
     wrapInVerification(wrappedCall.asTerm).asExprOf[R]
   }
 
-  /** Build `order.verifyWithMode[ObjType](obj, times)` — replaces the mock object with a verifying proxy */
-  private def buildVerifiedObj(using Quotes)(obj: quotes.reflect.Term, order: quotes.reflect.Term, times: quotes.reflect.Term): quotes.reflect.Term = {
-    import quotes.reflect.*
-    val objType = obj.tpe.widen.asType
-    Apply(
-      TypeApply(Select.unique(order, "verifyWithMode"), List(TypeTree.of(using objType))),
-      List(obj, times)
-    )
-  }
-
   /**
    * Collect hoisted statements, transform the invocation, wrap in `verification(...)`, and prepend any hoisted bindings.
    */

--- a/specs2/src/main/scala-3/org/mockito/specs2/MockitoCompat.scala
+++ b/specs2/src/main/scala-3/org/mockito/specs2/MockitoCompat.scala
@@ -1,0 +1,30 @@
+package org.mockito.specs2
+
+import org.mockito.{ Specs2VerifyMacro, VerifyOrder }
+import org.specs2.matcher.MatchResultCombinators.combineMatchResult
+import org.specs2.matcher.MatchResult
+
+/**
+ * Scala 3 compatibility layer for Mockito specs2 integration.
+ */
+private[specs2] trait MockitoCompat extends MockitoSpecs2Support {
+  protected def combineVerifications(left: Verification, right: => Verification): Verification =
+    left and right
+
+  /**
+   * class supporting 'was' and 'were' methods to forward mockito calls to the CallsMatcher matcher
+   */
+  class Calls {
+    inline def were[T](inline calls: => T)(using inline order: VerifyOrder): Verification =
+      Specs2VerifyMacro.wasMacro[T, Verification](calls)
+    inline def was[T](inline calls: T)(using inline order: VerifyOrder): Verification =
+      Specs2VerifyMacro.wasMacro[T, Verification](calls)
+  }
+
+  extension [T](m: MatchResult[T])
+    inline def andThen[O](inline calls: => O)(using inline order: VerifyOrder): Verification =
+      combineVerifications(m, Specs2VerifyMacro.wasMacro[O, Verification](calls))
+
+  inline def got[T](inline calls: => T)(using inline order: VerifyOrder): Verification =
+    Specs2VerifyMacro.gotMacro[T, Verification](calls)
+}


### PR DESCRIPTION
This enables Scala 3 for specs2 module and enables Scala 3 globally, thus finishing minimal Scala 3 support based on current set of tests.