### PR TITLE
Simplify Scala 3 macro implementation

### DIFF
--- a/macro/src/main/scala-3/org/mockito/ExpectMacro.scala
+++ b/macro/src/main/scala-3/org/mockito/ExpectMacro.scala
@@ -2,7 +2,6 @@ package org.mockito
 
 import org.mockito.Utils.*
 
-import scala.collection.mutable
 import scala.quoted.*
 
 /**
@@ -86,29 +85,6 @@ object ExpectMacro {
     Expr(detectIgnoringStubsInCalls(callsExpr.asTerm))
   }
 
-  /** Strip `Inlined` and empty `Block(Nil, expr)` wrappers from a term */
-  private def stripWrappers(using Quotes)(t: quotes.reflect.Term): quotes.reflect.Term = {
-    import quotes.reflect.*
-    t match {
-      case Inlined(_, _, body) => stripWrappers(body)
-      case Block(Nil, expr)    => stripWrappers(expr)
-      case other               => other
-    }
-  }
-
-  /** Build `order.verifyWithMode[ObjType](obj, times)` — replaces the mock object with a verifying proxy */
-  private def buildVerifiedObj(using Quotes)(obj: quotes.reflect.Term, order: quotes.reflect.Term, times: quotes.reflect.Term): quotes.reflect.Term = {
-    import quotes.reflect.*
-    val objType = obj.tpe.widen.asType
-    Apply(
-      TypeApply(Select.unique(order, "verifyWithMode"), List(TypeTree.of(using objType))),
-      List(obj, times)
-    )
-  }
-
-  /**
-   * Collect hoisted statements, transform the method invocation through `order.verifyWithMode`, wrap in `verification(...)`, and prepend any hoisted bindings.
-   */
   private def transformExpectation(using
       Quotes
   )(
@@ -117,60 +93,7 @@ object ExpectMacro {
       mode: Expr[ScalaVerificationMode]
   ): quotes.reflect.Term = {
     import quotes.reflect.*
-    val hoisted    = mutable.ListBuffer.empty[Statement]
-    val verifyCall = transformInvocation(invocation, order.asTerm, mode.asTerm, hoisted)
-    val verifyExpr = wrapInVerification(verifyCall)
-    if (hoisted.nonEmpty) Block(hoisted.toList, verifyExpr) else verifyExpr
-  }
-
-  /**
-   * Transform invocation: `obj.method(args)` → `order.verifyWithMode(obj, mode).method(transformedArgs)`
-   */
-  private def transformInvocation(using
-      Quotes
-  )(
-      invocation: quotes.reflect.Term,
-      order: quotes.reflect.Term,
-      times: quotes.reflect.Term,
-      hoisted: mutable.ListBuffer[quotes.reflect.Statement],
-      matcherValNames: Set[String] = Set.empty
-  ): quotes.reflect.Term = {
-    import quotes.reflect.*
-
-    invocation match {
-      case Block(stats, expr) =>
-        transformBlock(stats, expr, matcherValNames)((e, mvs) => transformInvocation(e, order, times, hoisted, mvs))
-
-      case inlined: Inlined =>
-        transformInvocation(inlined.body, order, times, hoisted, matcherValNames)
-
-      case Apply(select @ Select(obj, _), args) =>
-        Apply(
-          Select(buildVerifiedObj(obj, order, times), select.symbol),
-          transformArgsForApply(select, args, hoisted, matcherValNames)
-        )
-
-      case Apply(TypeApply(select @ Select(obj, _), targs), args) =>
-        Apply(
-          TypeApply(Select(buildVerifiedObj(obj, order, times), select.symbol), targs),
-          transformArgsForApply(TypeApply(select, targs), args, hoisted, matcherValNames)
-        )
-
-      case select @ Select(obj, _) =>
-        Select(buildVerifiedObj(obj, order, times), select.symbol)
-
-      case TypeApply(select @ Select(obj, _), targs) =>
-        TypeApply(Select(buildVerifiedObj(obj, order, times), select.symbol), targs)
-
-      case Apply(fun, args) =>
-        Apply(
-          transformInvocation(fun, order, times, hoisted, matcherValNames),
-          transformArgsForApply(fun, args, hoisted, matcherValNames)
-        )
-
-      case other =>
-        report.errorAndAbort(s"Could not transform expect invocation: ${other.show}")
-    }
+    hoistAndVerify(invocation, order.asTerm, mode.asTerm)
   }
 
   private def transformNoInteractionsExpectation(using Quotes)(mock: quotes.reflect.Term): quotes.reflect.Term = {

--- a/macro/src/main/scala-3/org/mockito/Specs2VerifyMacro.scala
+++ b/macro/src/main/scala-3/org/mockito/Specs2VerifyMacro.scala
@@ -1,7 +1,7 @@
 package org.mockito
 
 import org.mockito.MacroConstants.WordsToNumbers
-import org.mockito.Utils.{ buildVerifiedObj, callMethodInScope, transformArgsForApply, wrapInVerification }
+import org.mockito.Utils.{ buildVerifiedObj, callMethodInScope, stripWrappers, transformArgsForApply, wrapInVerification }
 import org.mockito.verification.VerificationMode
 
 import scala.quoted.*
@@ -58,12 +58,6 @@ object Specs2VerifyMacro {
   ): Option[quotes.reflect.Term] = {
     import quotes.reflect.*
 
-    def strip(t: Term): Term = t match {
-      case Inlined(_, _, body) => strip(body)
-      case Block(Nil, expr)    => strip(expr)
-      case other               => other
-    }
-
     def buildMode(name: String, times: Term): Term =
       name.toLowerCase match {
         case "exactly" => '{ Times(${ times.asExprOf[Int] }) }.asTerm
@@ -71,7 +65,7 @@ object Specs2VerifyMacro {
         case "atmost"  => '{ AtMost(${ times.asExprOf[Int] }) }.asTerm
       }
 
-    def extractModeAndMock(t: Term): Option[(Term, Term)] = strip(t) match {
+    def extractModeAndMock(t: Term): Option[(Term, Term)] = stripWrappers(t) match {
       case Inlined(_, _, body) =>
         extractModeAndMock(body)
 
@@ -168,7 +162,7 @@ object Specs2VerifyMacro {
         other
     }
 
-    strip(term) match {
+    stripWrappers(term) match {
       case Apply(TypeApply(Select(_, "noCallsTo"), _), List(obj)) =>
         Some(zeroInteractions(obj))
       case Apply(Select(_, "noCallsTo"), List(obj)) =>
@@ -205,7 +199,7 @@ object Specs2VerifyMacro {
       case Apply(fun, args)    => loop(fun) || args.exists(loop)
       case TypeApply(fun, _)   => loop(fun)
       case Select(qual, name)  => Specs2DslNames.contains(name) || loop(qual)
-      case _ => false
+      case _                   => false
     }
 
     loop(term)

--- a/macro/src/main/scala-3/org/mockito/Utils.scala
+++ b/macro/src/main/scala-3/org/mockito/Utils.scala
@@ -431,6 +431,16 @@ object Utils {
   private[mockito] def wrapInVerification(using Quotes)(call: quotes.reflect.Term): quotes.reflect.Term =
     callMethodInScope("verification", List(call))
 
+  /** Strip `Inlined` and empty `Block(Nil, expr)` wrappers from a term. */
+  private[mockito] def stripWrappers(using Quotes)(t: quotes.reflect.Term): quotes.reflect.Term = {
+    import quotes.reflect.*
+    t match {
+      case Inlined(_, _, body) => stripWrappers(body)
+      case Block(Nil, expr)    => stripWrappers(expr)
+      case other               => other
+    }
+  }
+
   /** Build `order.verifyWithMode[ObjType](obj, mode)` — replaces the mock object with a verifying proxy. */
   private[mockito] def buildVerifiedObj(using
       Quotes
@@ -441,5 +451,66 @@ object Utils {
       TypeApply(Select.unique(order, "verifyWithMode"), List(TypeTree.of(using objType))),
       List(obj, mode)
     )
+  }
+
+  /**
+   * Transform a verification invocation: `obj.method(args)` → `order.verifyWithMode(obj, mode).method(transformedArgs)`. Shared by [[VerifyMacro]] and [[ExpectMacro]].
+   */
+  private[mockito] def transformVerifyInvocation(using
+      Quotes
+  )(
+      invocation: quotes.reflect.Term,
+      order: quotes.reflect.Term,
+      mode: quotes.reflect.Term,
+      hoisted: mutable.ListBuffer[quotes.reflect.Statement],
+      matcherValNames: Set[String] = Set.empty
+  ): quotes.reflect.Term = {
+    import quotes.reflect.*
+
+    invocation match {
+      case Block(stats, expr) =>
+        transformBlock(stats, expr, matcherValNames)((e, mvs) => transformVerifyInvocation(e, order, mode, hoisted, mvs))
+
+      case Inlined(_, _, body) =>
+        transformVerifyInvocation(body, order, mode, hoisted, matcherValNames)
+
+      case Apply(select @ Select(obj, _), args) =>
+        Apply(
+          Select(buildVerifiedObj(obj, order, mode), select.symbol),
+          transformArgsForApply(select, args, hoisted, matcherValNames)
+        )
+
+      case Apply(TypeApply(select @ Select(obj, _), targs), args) =>
+        Apply(
+          TypeApply(Select(buildVerifiedObj(obj, order, mode), select.symbol), targs),
+          transformArgsForApply(TypeApply(select, targs), args, hoisted, matcherValNames)
+        )
+
+      case select @ Select(obj, _) =>
+        Select(buildVerifiedObj(obj, order, mode), select.symbol)
+
+      case TypeApply(select @ Select(obj, _), targs) =>
+        TypeApply(Select(buildVerifiedObj(obj, order, mode), select.symbol), targs)
+
+      case Apply(fun, args) =>
+        Apply(
+          transformVerifyInvocation(fun, order, mode, hoisted, matcherValNames),
+          transformArgsForApply(fun, args, hoisted, matcherValNames)
+        )
+
+      case other =>
+        report.errorAndAbort(s"Could not transform verification invocation: ${other.show}")
+    }
+  }
+
+  /** Collect hoisted statements, transform an invocation for verification, wrap in `verification(...)`, and prepend any hoisted bindings. */
+  private[mockito] def hoistAndVerify(using
+      Quotes
+  )(invocation: quotes.reflect.Term, order: quotes.reflect.Term, mode: quotes.reflect.Term): quotes.reflect.Term = {
+    import quotes.reflect.*
+    val hoisted     = mutable.ListBuffer.empty[Statement]
+    val transformed = transformVerifyInvocation(invocation, order, mode, hoisted)
+    val verifyExpr  = wrapInVerification(transformed)
+    if (hoisted.nonEmpty) Block(hoisted.toList, verifyExpr) else verifyExpr
   }
 }

--- a/macro/src/main/scala-3/org/mockito/VerifyMacro.scala
+++ b/macro/src/main/scala-3/org/mockito/VerifyMacro.scala
@@ -3,7 +3,6 @@ package org.mockito
 import org.mockito.Utils.*
 import org.mockito.VerifyMacroRuntime.{ Never, NeverAgain, Once }
 
-import scala.collection.mutable
 import scala.quoted.*
 
 /**
@@ -79,66 +78,8 @@ object VerifyMacro {
     wrapInVerification(wrappedCall.asTerm).asExprOf[R]
   }
 
-  /**
-   * Collect hoisted statements, transform the invocation, wrap in `verification(...)`, and prepend any hoisted bindings.
-   */
-  private def transformVerification(using Quotes)(invocation: quotes.reflect.Term, order: quotes.reflect.Term, times: quotes.reflect.Term): quotes.reflect.Term = {
-    import quotes.reflect.*
-    val hoisted     = mutable.ListBuffer.empty[Statement]
-    val transformed = transformInvocation(invocation, order, times, hoisted)
-    val verifyExpr  = wrapInVerification(transformed)
-    if (hoisted.nonEmpty) Block(hoisted.toList, verifyExpr) else verifyExpr
-  }
-
-  /**
-   * Transform invocation: `obj.method(args)` → `order.verifyWithMode(obj, times).method(transformedArgs)`
-   */
-  private def transformInvocation(using
-      Quotes
-  )(
-      invocation: quotes.reflect.Term,
-      order: quotes.reflect.Term,
-      times: quotes.reflect.Term,
-      hoisted: mutable.ListBuffer[quotes.reflect.Statement],
-      matcherValNames: Set[String] = Set.empty
-  ): quotes.reflect.Term = {
-    import quotes.reflect.*
-
-    invocation match {
-      case Block(stats, expr) =>
-        transformBlock(stats, expr, matcherValNames)((e, mvs) => transformInvocation(e, order, times, hoisted, mvs))
-
-      case Inlined(_, _, expansion) =>
-        transformInvocation(expansion, order, times, hoisted, matcherValNames)
-
-      case Apply(select @ Select(obj, _), args) =>
-        Apply(
-          Select(buildVerifiedObj(obj, order, times), select.symbol),
-          transformArgsForApply(select, args, hoisted, matcherValNames)
-        )
-
-      case Apply(TypeApply(select @ Select(obj, _), targs), args) =>
-        Apply(
-          TypeApply(Select(buildVerifiedObj(obj, order, times), select.symbol), targs),
-          transformArgsForApply(TypeApply(select, targs), args, hoisted, matcherValNames)
-        )
-
-      case select @ Select(obj, _) =>
-        Select(buildVerifiedObj(obj, order, times), select.symbol)
-
-      case TypeApply(select @ Select(obj, _), targs) =>
-        TypeApply(Select(buildVerifiedObj(obj, order, times), select.symbol), targs)
-
-      case Apply(fun, args) =>
-        Apply(
-          transformInvocation(fun, order, times, hoisted, matcherValNames),
-          transformArgsForApply(fun, args, hoisted, matcherValNames)
-        )
-
-      case other =>
-        report.errorAndAbort(s"Could not transform verification invocation: ${other.show}")
-    }
-  }
+  private def transformVerification(using Quotes)(invocation: quotes.reflect.Term, order: quotes.reflect.Term, times: quotes.reflect.Term): quotes.reflect.Term =
+    hoistAndVerify(invocation, order, times)
 
   /** Detect if a `calledAgain(...)` expression is the lenient variant (i.e. `calledAgain(ignoringStubs)`) by inspecting the AST. */
   private def detectIgnoringStubs(using Quotes)(term: quotes.reflect.Term): Boolean = {

--- a/macro/src/main/scala-3/org/mockito/WhenMacro.scala
+++ b/macro/src/main/scala-3/org/mockito/WhenMacro.scala
@@ -1,7 +1,6 @@
 package org.mockito
 
 import org.mockito.Utils.*
-import org.mockito.WhenDslKeywords.*
 import org.mockito.WhenMacroRuntime.{ AnswerActions, AnswerPFActions, RealMethod }
 import org.mockito.stubbing.{ OngoingStubbing, ScalaFirstStubbing, ScalaOngoingStubbing }
 import org.scalactic.Prettifier
@@ -68,22 +67,6 @@ object WhenMacro {
     buildActionWrapper[T]("org.mockito.WhenMacroRuntime.AnswerPFActions", buildScalaFirstStubbing[T](stubbing))
   }
 
-  inline def shouldReturn[T, R](inline stubbing: => T, inline v: => R)(using $pt: Prettifier): OngoingStubbing[T] =
-    ${ shouldReturnImpl[T, R]('stubbing, 'v, '$pt) }
-
-  def shouldReturnImpl[T: Type, R: Type](
-      stubbing: Expr[T],
-      v: Expr[R],
-      pt: Expr[Prettifier]
-  )(using Quotes): Expr[OngoingStubbing[T]] = {
-    import quotes.reflect.*
-    val returnActionsClass = Symbol.requiredClass("org.mockito.IdiomaticMockitoBaseRuntime.ReturnActions")
-    Apply(
-      Select.overloaded(New(TypeTree.ref(returnActionsClass)), "<init>", List(TypeRepr.of[T]), Nil),
-      List(buildScalaFirstStubbing[T](stubbing))
-    ).asExprOf[OngoingStubbing[T]]
-  }
-
   inline def isLenient[T](inline stubbing: => T)(using $pt: Prettifier): ScalaFirstStubbing[T] =
     ${ isLenientImpl[T]('stubbing, '$pt) }
 
@@ -108,46 +91,6 @@ object WhenMacro {
   )(using Quotes): Expr[ScalaOngoingStubbing[T]] = {
     val transformed = doTransformInvocation(stubbing)
     '{ new ScalaOngoingStubbing[T](org.mockito.Mockito.when[T]($transformed).thenCallRealMethod()) }
-  }
-
-  inline def shouldThrow[T](inline stubbing: => T, inline throwables: Throwable*)(using $pt: Prettifier): OngoingStubbing[T] =
-    ${ shouldThrowImpl[T]('stubbing, 'throwables, '$pt) }
-
-  def shouldThrowImpl[T: Type](
-      stubbing: Expr[T],
-      throwables: Expr[Seq[Throwable]],
-      pt: Expr[Prettifier]
-  )(using Quotes): Expr[OngoingStubbing[T]] = {
-    import quotes.reflect.*
-    val throwActionsClass = Symbol.requiredClass("org.mockito.IdiomaticMockitoBaseRuntime.ThrowActions")
-    Apply(
-      Select.overloaded(New(TypeTree.ref(throwActionsClass)), "<init>", List(TypeRepr.of[T]), Nil),
-      List(buildScalaFirstStubbing[T](stubbing))
-    ).asExprOf[OngoingStubbing[T]]
-  }
-
-  inline def shouldAnswer[T, P1, R](inline stubbing: => T, inline f: Any)(using $pt: Prettifier): AnswerActions[T] =
-    ${ shouldAnswerImpl[T, P1, R]('stubbing, 'f, '$pt) }
-
-  def shouldAnswerImpl[T: Type, P1: Type, R: Type](
-      stubbing: Expr[T],
-      f: Expr[Any],
-      pt: Expr[Prettifier]
-  )(using Quotes): Expr[AnswerActions[T]] = {
-    val transformed = doTransformInvocation(stubbing)
-    '{ new WhenMacroRuntime.AnswerActions[T](org.mockito.Mockito.when[T]($transformed)) }
-  }
-
-  inline def shouldAnswerPF[T, P, R](inline stubbing: => T, inline f: PartialFunction[P, R])(using $pt: Prettifier): AnswerPFActions[T] =
-    ${ shouldAnswerPFImpl[T, P, R]('stubbing, 'f, '$pt) }
-
-  def shouldAnswerPFImpl[T: Type, P: Type, R: Type](
-      stubbing: Expr[T],
-      f: Expr[PartialFunction[P, R]],
-      pt: Expr[Prettifier]
-  )(using Quotes): Expr[AnswerPFActions[T]] = {
-    val transformed = doTransformInvocation(stubbing)
-    '{ new WhenMacroRuntime.AnswerPFActions[T](org.mockito.Mockito.when[T]($transformed)) }
   }
 
   /**

--- a/scalatest/src/test/scala/user/org/mockito/stubbing/DefaultAnswerTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/stubbing/DefaultAnswerTest.scala
@@ -6,7 +6,7 @@ import org.mockito.stubbing.DefaultAnswer
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
-import org.scalatest.{OptionValues, TryValues}
+import org.scalatest.{ OptionValues, TryValues }
 import user.org.mockito.stubbing.DefaultAnswerTest.*
 
 object DefaultAnswerTest {


### PR DESCRIPTION
This is primarily a refactoring change. It reduces duplication across Scala 3 macros, makes the implementation more consistent, and creates a single place to maintain shared verification transformation behavior.

  • simplify the Scala 3 macro implementation by moving shared verification-tree rewriting logic into common utilities
  • remove duplicated verification transformation code from VerifyMacro and ExpectMacro
  • reuse shared wrapper-stripping logic in Specs2VerifyMacro and trim redundant Scala 3 macro code in WhenMacro
  
