### PR TITLE
Implement mockStatic

### DIFF
--- a/common/src/main/scala/org/mockito/MockitoAPI.scala
+++ b/common/src/main/scala/org/mockito/MockitoAPI.scala
@@ -540,6 +540,50 @@ private[mockito] trait MockitoEnhancer extends MockCreator {
   def spyLambda[T <: AnyRef: ClassTag](realObj: T): T = Mockito.mock(clazz, AdditionalAnswers.delegatesTo(realObj))
 
   /**
+   * Delegates to <code>Mockito.mockStatic(classToMock: Class[T], mockSettings: MockSettings)</code>. Creates a thread-local mock for all static methods of <code>T</code>. The
+   * returned controller must be closed after use.
+   *
+   * Uses the implicit <code>DefaultAnswer</code> (defaults to <code>ReturnsSmartNulls</code>) just like <code>mock[T]</code>.
+   */
+  def mockStatic[T <: AnyRef: ClassTag](implicit defaultAnswer: DefaultAnswer): MockedStatic[T] =
+    mockStatic[T](withSettings(defaultAnswer))
+
+  /**
+   * Creates a static mock using a raw Mockito <code>Answer</code> by wrapping it in a scala-mockito <code>DefaultAnswer</code>.
+   */
+  def mockStatic[T <: AnyRef: ClassTag](defaultAnswer: Answer[?]): MockedStatic[T] =
+    mockStatic[T](DefaultAnswer(defaultAnswer))
+
+  /**
+   * Delegates to <code>Mockito.mockStatic(classToMock: Class[T], mockSettings: MockSettings)</code> with a settings object built from the given <code>DefaultAnswer</code>.
+   */
+  def mockStatic[T <: AnyRef: ClassTag](defaultAnswer: DefaultAnswer): MockedStatic[T] =
+    mockStatic[T](withSettings(defaultAnswer))
+
+  /**
+   * Delegates to <code>Mockito.mockStatic(classToMock: Class[T], name: String)</code>.
+   */
+  def mockStatic[T <: AnyRef: ClassTag](name: String)(implicit defaultAnswer: DefaultAnswer): MockedStatic[T] =
+    mockStatic[T](withSettings(defaultAnswer).name(name))
+
+  /**
+   * Delegates to <code>Mockito.mockStatic(classToMock: Class[T], mockSettings: MockSettings)</code>.
+   */
+  def mockStatic[T <: AnyRef: ClassTag](mockSettings: MockSettings): MockedStatic[T] =
+    Mockito.mockStatic(clazz[T], mockSettings)
+
+  /**
+   * Mocks all static methods of <code>T</code> for the duration of <code>block</code>, and closes the static mock afterwards.
+   *
+   * Note: the mock is thread-local &mdash; threads spawned inside the block will see the real static methods, not the mock.
+   */
+  def withStaticMocked[T <: AnyRef: ClassTag](block: MockedStatic[T] => Any)(implicit defaultAnswer: DefaultAnswer): Unit = {
+    val ms = mockStatic[T]
+    try { block(ms); () }
+    finally ms.close()
+  }
+
+  /**
    * Mocks the specified object only for the context of the block
    */
   def withObjectMocked[O <: AnyRef: ClassTag](block: => Any)(implicit defaultAnswer: DefaultAnswer, $pt: Prettifier): Unit =

--- a/scalatest/src/test/java/user/org/mockito/model/JavaStaticFoo.java
+++ b/scalatest/src/test/java/user/org/mockito/model/JavaStaticFoo.java
@@ -1,0 +1,12 @@
+package user.org.mockito.model;
+
+public class JavaStaticFoo {
+
+    public static String greet(String name) {
+        return "hello " + name;
+    }
+
+    public static int sum(int a, int b) {
+        return a + b;
+    }
+}

--- a/scalatest/src/test/scala/user/org/mockito/MockitoSugarTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/MockitoSugarTest.scala
@@ -13,7 +13,7 @@ import org.scalactic.Prettifier
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{ EitherValues, OptionValues }
 import user.org.mockito.matchers.{ ValueCaseClassInt, ValueCaseClassString, ValueClass }
-import user.org.mockito.model.JavaFoo
+import user.org.mockito.model.{ JavaFoo, JavaStaticFoo }
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -466,6 +466,77 @@ class MockitoSugarTest extends AnyWordSpec with MockitoSugar with Matchers with 
 
       aSpy("hi!") shouldBe "mocked!"
       verify(aSpy).apply("hi!")
+    }
+  }
+
+  "mockStatic[T]" should {
+    "replace all static methods with defaults and allow stubbing one" in {
+      val ms = mockStatic[JavaStaticFoo]
+      try {
+        JavaStaticFoo.greet("world") shouldBe ""
+        JavaStaticFoo.sum(2, 3) shouldBe 0
+
+        ms.when { () => JavaStaticFoo.greet("world"); () }.thenReturn("mocked!")
+
+        JavaStaticFoo.greet("world") shouldBe "mocked!"
+        JavaStaticFoo.sum(2, 3) shouldBe 0
+
+        ms.verify({ () => JavaStaticFoo.greet("world"); () }, times(2))
+      } finally ms.close()
+
+      JavaStaticFoo.greet("world") shouldBe "hello world"
+    }
+
+    "accept a name" in {
+      val ms = mockStatic[JavaStaticFoo]("namedMock")
+      try
+        JavaStaticFoo.sum(1, 2) shouldBe 0
+      finally ms.close()
+    }
+
+    "accept a raw Answer" in {
+      val ms = mockStatic[JavaStaticFoo](Answers.CALLS_REAL_METHODS)
+      try
+        JavaStaticFoo.sum(4, 5) shouldBe 9
+      finally ms.close()
+    }
+
+    "accept a DefaultAnswer" in {
+      val ms = mockStatic[JavaStaticFoo](CallsRealMethods: DefaultAnswer)
+      try
+        JavaStaticFoo.greet("x") shouldBe "hello x"
+      finally ms.close()
+    }
+
+    "accept custom mock settings" in {
+      val ms = mockStatic[JavaStaticFoo](withSettings.name("customMock"))
+      try
+        JavaStaticFoo.sum(4, 5) shouldBe 0
+      finally ms.close()
+    }
+  }
+
+  "withStaticMocked[T]" should {
+    "mock static methods only for the duration of the block and auto-close" in {
+      JavaStaticFoo.greet("bob") shouldBe "hello bob"
+
+      withStaticMocked[JavaStaticFoo] { ms =>
+        JavaStaticFoo.greet("bob") shouldBe ""
+        ms.when { () => JavaStaticFoo.greet("bob"); () }.thenReturn("mocked!")
+        JavaStaticFoo.greet("bob") shouldBe "mocked!"
+      }
+
+      JavaStaticFoo.greet("bob") shouldBe "hello bob"
+    }
+
+    "close the static mock even when the block throws" in {
+      a[RuntimeException] shouldBe thrownBy {
+        withStaticMocked[JavaStaticFoo] { _ =>
+          throw new RuntimeException("boom")
+        }
+      }
+
+      JavaStaticFoo.greet("alice") shouldBe "hello alice"
     }
   }
 }


### PR DESCRIPTION
This PR implements `mockStatic` for improving experience when dealing with java stdlib statics and in general third-party java libraries.