### PR TITLE
Upgrade Scala 3 LTS to 3.3.8 and fix ambiguous `shouldReturn`/`mustReturn` overloads

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import scala.language.postfixOps
 
 val currentScalaVersion = "2.13.18"
-val scala3Version       = "3.3.7"
+val scala3Version       = "3.3.8"
 
 inThisBuild(
   Seq(

--- a/core/src/main/scala-3/org/mockito/IdiomaticStubbing.scala
+++ b/core/src/main/scala-3/org/mockito/IdiomaticStubbing.scala
@@ -15,13 +15,9 @@ trait IdiomaticStubbing extends IdiomaticStubbingRuntime {
   val called: Called.type = Called
 
   extension [T](inline stubbing: T) {
-    transparent inline def shouldReturn: ReturnActions[T]                        = WhenMacro.shouldReturn[T](stubbing).asInstanceOf[ReturnActions[T]]
-    transparent inline def mustReturn: ReturnActions[T]                          = WhenMacro.shouldReturn[T](stubbing).asInstanceOf[ReturnActions[T]]
-    transparent inline def returns: ReturnActions[T]                             = WhenMacro.shouldReturn[T](stubbing).asInstanceOf[ReturnActions[T]]
-    transparent inline infix def shouldReturn(value: T): ScalaOngoingStubbing[T] =
-      WhenMacro.shouldReturn[T](stubbing).asInstanceOf[ReturnActions[T]](value)
-    transparent inline infix def mustReturn(value: T): ScalaOngoingStubbing[T] =
-      WhenMacro.shouldReturn[T](stubbing).asInstanceOf[ReturnActions[T]](value)
+    transparent inline def shouldReturn[V](inline value: V, inline values: V*): ScalaOngoingStubbing[?] = WhenMacro.returnsValue[T, V](stubbing, value, values*)
+    transparent inline def mustReturn[V](inline value: V, inline values: V*): ScalaOngoingStubbing[?]   = WhenMacro.returnsValue[T, V](stubbing, value, values*)
+    transparent inline def returns[V](inline value: V, inline values: V*): ScalaOngoingStubbing[?]      = WhenMacro.returnsValue[T, V](stubbing, value, values*)
 
     transparent inline def shouldCall(crm: RealMethod.type): ScalaOngoingStubbing[T] = WhenMacro.shouldCallRealMethod[T](stubbing)(using org.scalactic.Prettifier.default)
     transparent inline def mustCall(crm: RealMethod.type): ScalaOngoingStubbing[T]   = WhenMacro.shouldCallRealMethod[T](stubbing)(using org.scalactic.Prettifier.default)
@@ -44,6 +40,26 @@ trait IdiomaticStubbing extends IdiomaticStubbingRuntime {
     transparent inline def shouldDoNothing(): Unit = DoSomethingMacro.doesNothing(stubbing)
     transparent inline def mustDoNothing(): Unit   = DoSomethingMacro.doesNothing(stubbing)
     transparent inline def doesNothing(): Unit     = DoSomethingMacro.doesNothing(stubbing)
+  }
+
+  // More specific overloads for methods that return a function: they give a placeholder-lambda value
+  // (e.g. `shouldReturn(_.toString)`) its expected type, which the generic `[V]` overload cannot infer.
+  extension [I, O](inline stubbing: I => O) {
+    transparent inline def shouldReturn(value: I => O, values: (I => O)*): ScalaOngoingStubbing[?] = WhenMacro.returnsValue[I => O, I => O](stubbing, value, values*)
+    transparent inline def mustReturn(value: I => O, values: (I => O)*): ScalaOngoingStubbing[?]   = WhenMacro.returnsValue[I => O, I => O](stubbing, value, values*)
+    transparent inline def returns(value: I => O, values: (I => O)*): ScalaOngoingStubbing[?]      = WhenMacro.returnsValue[I => O, I => O](stubbing, value, values*)
+  }
+
+  // `PartialFunction` is a subtype of `Function1`, so without this more specific overload the one above
+  // would widen a `{ case ... }` value to a total function, elaborating it as a plain lambda that then
+  // fails with a `ClassCastException` when the (partial-function-returning) mock is invoked.
+  extension [I, O](inline stubbing: PartialFunction[I, O]) {
+    transparent inline def shouldReturn(value: PartialFunction[I, O], values: PartialFunction[I, O]*): ScalaOngoingStubbing[?] =
+      WhenMacro.returnsValue[PartialFunction[I, O], PartialFunction[I, O]](stubbing, value, values*)
+    transparent inline def mustReturn(value: PartialFunction[I, O], values: PartialFunction[I, O]*): ScalaOngoingStubbing[?] =
+      WhenMacro.returnsValue[PartialFunction[I, O], PartialFunction[I, O]](stubbing, value, values*)
+    transparent inline def returns(value: PartialFunction[I, O], values: PartialFunction[I, O]*): ScalaOngoingStubbing[?] =
+      WhenMacro.returnsValue[PartialFunction[I, O], PartialFunction[I, O]](stubbing, value, values*)
   }
 
   extension [R](v: R) {

--- a/macro/src/main/scala-3/org/mockito/WhenMacro.scala
+++ b/macro/src/main/scala-3/org/mockito/WhenMacro.scala
@@ -43,6 +43,118 @@ object WhenMacro {
     buildActionWrapper[T]("org.mockito.IdiomaticMockitoBaseRuntime.ReturnActions", buildScalaFirstStubbing[T](stubbing))
   }
 
+  /**
+   * Value-aware stubbing used by `shouldReturn`/`mustReturn`/`returns`.
+   *
+   * Taking the returned value(s) as a separate type parameter `V` (rather than unifying with the stubbed type `T`) lets this macro decide, by inspecting the two types, how to
+   * build the stubbing:
+   *   - `V` conforms to `T` (normal/sub-typed value): stub at `T`.
+   *   - `V` numerically widens to `T` (e.g. `Long` method stubbed with an `Int`): stub at `T`, coercing the value with `toLong`/`toDouble`/... so the runtime value has the
+   *     method's return type instead of being boxed as the narrower type.
+   *   - `T` is a polymorphic type whose parameter defaulted (e.g. `Either[String, Resp[Any]]`) while `V` is more specific: stub at `V`, so the value's type drives inference.
+   *   - otherwise the stub is a genuine type error and is rejected with a clear message.
+   */
+  transparent inline def returnsValue[T, V](inline stubbing: T, inline value: V, inline values: V*): ScalaOngoingStubbing[?] =
+    ${ returnsValueMacro[T, V]('stubbing, 'value, 'values) }
+
+  // Scala weak conformance is not a linear order: the main chain is Byte < Short < Int < Long < Float <
+  // Double, while Char widens directly to Int (and wider) but is unrelated to Byte/Short. Each key maps
+  // to the set of types it may widen to, so e.g. Byte -> Char is correctly *not* a widening.
+  private val numericWidening: Map[String, Set[String]] = {
+    val chain   = List("scala.Byte", "scala.Short", "scala.Int", "scala.Long", "scala.Float", "scala.Double")
+    val onChain = chain.tails.collect { case from :: wider => from -> wider.toSet }.toMap
+    onChain + ("scala.Char" -> Set("scala.Int", "scala.Long", "scala.Float", "scala.Double"))
+  }
+
+  def returnsValueMacro[T: Type, V: Type](stubbing: Expr[T], value: Expr[V], values: Expr[Seq[V]])(using Quotes): Expr[ScalaOngoingStubbing[?]] = {
+    import quotes.reflect.*
+    val transformed = doTransformInvocation(stubbing)
+    val tT          = TypeRepr.of[T].widen.dealias
+    val tV          = TypeRepr.of[V].widen.dealias
+
+    val numericWiden = numericWidening.get(tV.typeSymbol.fullName).exists(_.contains(tT.typeSymbol.fullName))
+
+    // Numeric literal narrowing (per the spec, mirrored by plain Scala assignment and the Scala 2 DSL):
+    // an `Int` *constant* whose value is in the target's range may narrow to Byte/Short/Char. `Expr#value`
+    // returns `Some` exactly for compile-time constants (literals and constant-folded `final val`s), so
+    // out-of-range literals and non-constant `Int` values are still rejected, just like the compiler.
+    def intConst(e: Expr[V]): Option[Int] = if (tV =:= TypeRepr.of[Int]) e.asExprOf[Int].value else None
+    def inTargetRange(n: Int): Boolean    = tT.typeSymbol.fullName match {
+      case "scala.Byte"  => n >= Byte.MinValue && n <= Byte.MaxValue
+      case "scala.Short" => n >= Short.MinValue && n <= Short.MaxValue
+      case "scala.Char"  => n >= Char.MinValue && n <= Char.MaxValue
+      case _             => false
+    }
+    val literalNarrow =
+      intConst(value).exists(inTargetRange) && Varargs.unapply(values).exists(_.forall(intConst(_).exists(inTargetRange)))
+
+    // Treats `Any`/`Nothing` positions in the target as wildcards, so a polymorphic method whose
+    // type parameter defaulted to `Any` accepts a more specific value, while genuinely unrelated
+    // types (e.g. `Int` vs `String`) are rejected.
+    def compatible(t: TypeRepr, v: TypeRepr): Boolean =
+      (v <:< t) || (t =:= TypeRepr.of[Any]) || (t =:= TypeRepr.of[Nothing]) || {
+        (t, v) match {
+          case (AppliedType(c1, a1), AppliedType(c2, a2)) if c1 =:= c2 && a1.length == a2.length =>
+            a1.zip(a2).forall((x, y) => compatible(x, y))
+          case _ => false
+        }
+      }
+
+    // A single quote is emitted per expansion (rather than unifying several `if`/`else` branches),
+    // so `transparent inline` can refine the result to the precise `ScalaOngoingStubbing[targetType]`.
+    val boxed: Map[String, TypeRepr] = Map(
+      "scala.Byte"    -> TypeRepr.of[java.lang.Byte],
+      "scala.Short"   -> TypeRepr.of[java.lang.Short],
+      "scala.Char"    -> TypeRepr.of[java.lang.Character],
+      "scala.Int"     -> TypeRepr.of[java.lang.Integer],
+      "scala.Long"    -> TypeRepr.of[java.lang.Long],
+      "scala.Float"   -> TypeRepr.of[java.lang.Float],
+      "scala.Double"  -> TypeRepr.of[java.lang.Double],
+      "scala.Boolean" -> TypeRepr.of[java.lang.Boolean]
+    )
+    // `Int` stubbed on a method returning e.g. `java.lang.Long` (typically Java interop): a Scala numeric
+    // that weakly conforms to the target's primitive is widened and boxed, matching the Scala 2 DSL.
+    // `boxWidenPrim` is the primitive to widen the value to before boxing (the value's own type when its
+    // box already conforms, e.g. for a supertype target like `Number`).
+    val boxWidenPrim: Option[String] = {
+      val widenTargets = tV.typeSymbol.fullName :: numericWidening.getOrElse(tV.typeSymbol.fullName, Set.empty).toList
+      widenTargets.find(p => boxed.get(p).exists(_ <:< tT))
+    }
+    val boxWiden = boxWidenPrim.isDefined
+
+    val numericCoerce: Option[String] = Option.when(numericWiden || literalNarrow)("to" + tT.typeSymbol.name)
+    // `Any`/`Nothing` (e.g. `returns ???`): the value can't be statically re-typed, so cast at runtime.
+    val runtimeCast                                     = tV =:= TypeRepr.of[Any]
+    val (targetType, castStubbing): (TypeRepr, Boolean) =
+      if (tV <:< tT || numericWiden || literalNarrow || boxWiden || runtimeCast) (tT, false)
+      else if (compatible(tT, tV)) (tV, true)
+      else report.errorAndAbort(s"Cannot stub a method returning ${tT.show} with a value of type ${tV.show}")
+
+    targetType.asType match {
+      case '[tgt] =>
+        val whenArg: Expr[tgt]            = if (castStubbing) '{ $transformed.asInstanceOf[tgt] } else transformed.asExprOf[tgt]
+        def coerce(e: Expr[V]): Expr[tgt] =
+          numericCoerce match {
+            case Some(n)       => Select.unique(e.asTerm, n).asExprOf[tgt]
+            case _ if boxWiden =>
+              // Widen to the target's primitive (a no-op when it equals the value's type), then box via `Any`.
+              val prim               = boxWidenPrim.get
+              val widened: Expr[Any] =
+                if (prim == tV.typeSymbol.fullName) e.asExprOf[Any]
+                else Select.unique(e.asTerm, "to" + prim.stripPrefix("scala.")).asExprOf[Any]
+              '{ $widened.asInstanceOf[tgt] }
+            case _ if runtimeCast => '{ $e.asInstanceOf[tgt] }
+            case _                => e.asExprOf[tgt]
+          }
+        val plainPassThrough     = numericCoerce.isEmpty && !boxWiden && !runtimeCast
+        val first: Expr[tgt]     = coerce(value)
+        val rest: Expr[Seq[tgt]] =
+          if (plainPassThrough) values.asExprOf[Seq[tgt]]
+          else '{ $values.map(x => ${ coerce('x) }) }
+        '{ new ScalaFirstStubbing[tgt](org.mockito.Mockito.when[tgt]($whenArg)).thenReturn($first, $rest*) }
+    }
+  }
+
   inline def shouldThrow[T](inline stubbing: T): Any =
     ${ shouldThrowMacro[T]('stubbing) }
 

--- a/scalatest/src/test/scala/user/org/mockito/IdiomaticStubbingTest.scala
+++ b/scalatest/src/test/scala/user/org/mockito/IdiomaticStubbingTest.scala
@@ -15,6 +15,22 @@ trait PolymorphicClient {
   def request[A](path: String)(implicit codec: PolymorphicCodec[A]): Either[String, PolymorphicResponse[A]]
 }
 
+trait NumericReturns {
+  def getByte: Byte
+  def getShort: Short
+  def getChar: Char
+  def getInt: Int
+  def getLong: Long
+  def getDouble: Double
+}
+
+trait BoxedNumericReturns {
+  def getBoxedInteger: java.lang.Integer
+  def getBoxedLong: java.lang.Long
+  def getBoxedDouble: java.lang.Double
+  def getBoxedByte: java.lang.Byte
+}
+
 class IdiomaticStubbingTest extends AnyWordSpec with Matchers with ArgumentMatchersSugar with IdiomaticMockitoTestSetup with IdiomaticStubbing {
 
   forAll(scenarios) { (testDouble, orgDouble, foo) =>
@@ -192,6 +208,37 @@ class IdiomaticStubbingTest extends AnyWordSpec with Matchers with ArgumentMatch
         org.iReturnAFunction(3)(3) shouldBe "9"
       }
 
+      "stub a method that returns a partial function with a case-block literal" in {
+        val org = orgDouble()
+
+        org.iReturnAPartialFunction(*) shouldReturn { case i => i.toString }
+
+        org.iReturnAPartialFunction(0)(42) shouldBe "42"
+      }
+
+      "set consecutive return values when passed more than one value" in {
+        val org = orgDouble()
+
+        org.doSomethingWithThisInt(*) shouldReturn (1, 2, 3)
+
+        org.doSomethingWithThisInt(0) shouldBe 1
+        org.doSomethingWithThisInt(0) shouldBe 2
+        org.doSomethingWithThisInt(0) shouldBe 3
+        org.doSomethingWithThisInt(0) shouldBe 3
+      }
+
+      "stub a tuple return value (via extra parens or the -> arrow, since the DSL takes consecutive values as varargs)" in {
+        val org = orgDouble()
+
+        org.returnsATuple shouldReturn ((1, "mocked"))
+
+        org.returnsATuple shouldBe (1, "mocked")
+
+        org.returnsATuple shouldReturn 2 -> "mocked again"
+
+        org.returnsATuple shouldBe (2, "mocked again")
+      }
+
       "doStub a value class return value" in {
         val org = orgDouble()
 
@@ -365,7 +412,7 @@ class IdiomaticStubbingTest extends AnyWordSpec with Matchers with ArgumentMatch
   }
 
   "mock" should {
-    "infer the type parameter for shouldReturn on a polymorphic method from the returned value" in {
+    "infer the type parameter for `shouldReturn` on a polymorphic method from the returned value" in {
       implicit object StringCodec extends PolymorphicCodec[String]
 
       def stubResponse[A](
@@ -382,7 +429,7 @@ class IdiomaticStubbingTest extends AnyWordSpec with Matchers with ArgumentMatch
       client.request[String]("path") shouldBe expected
     }
 
-    "infer the type parameter for mustReturn on a polymorphic method from the returned value" in {
+    "infer the type parameter for `mustReturn` on a polymorphic method from the returned value" in {
       implicit object StringCodec extends PolymorphicCodec[String]
 
       def stubResponse[A](
@@ -397,6 +444,96 @@ class IdiomaticStubbingTest extends AnyWordSpec with Matchers with ArgumentMatch
       stubResponse(client, expected)
 
       client.request[String]("path") shouldBe expected
+    }
+
+    "infer the type parameter for `returns` on a polymorphic method from the returned value" in {
+      implicit object StringCodec extends PolymorphicCodec[String]
+
+      def stubResponse[A](
+          client: PolymorphicClient,
+          response: Either[String, PolymorphicResponse[A]]
+      )(implicit codec: PolymorphicCodec[A]): org.mockito.stubbing.ScalaOngoingStubbing[Either[String, PolymorphicResponse[A]]] =
+        client.request("path")(*) returns response
+
+      val client   = mock[PolymorphicClient]
+      val expected = Right(PolymorphicResponse("ok")): Either[String, PolymorphicResponse[String]]
+
+      stubResponse(client, expected)
+
+      client.request[String]("path") shouldBe expected
+    }
+
+    "widen a narrower numeric value to the method's return type" in {
+      val m = mock[NumericReturns]
+
+      m.getLong shouldReturn 1
+      m.getDouble mustReturn 2
+      m.getInt returns 3
+
+      m.getLong shouldBe 1L
+      m.getDouble shouldBe 2.0
+      m.getInt shouldBe 3
+    }
+
+    "narrow an Int constant literal in range to a Byte/Short/Char return type" in {
+      val m = mock[NumericReturns]
+
+      m.getByte shouldReturn 5
+      m.getShort mustReturn 6
+      m.getChar returns 65
+
+      m.getByte shouldBe 5.toByte
+      m.getShort shouldBe 6.toShort
+      m.getChar shouldBe 'A'
+    }
+
+    "reject narrowing an out-of-range or non-constant value (as plain Scala does)" in {
+      "val m = mock[NumericReturns]; m.getByte shouldReturn 5000" shouldNot typeCheck
+      "val m = mock[NumericReturns]; val i = 5; m.getByte shouldReturn i" shouldNot typeCheck
+      "val m = mock[NumericReturns]; m.getInt shouldReturn 5L" shouldNot typeCheck
+    }
+
+    "widen a non-constant numeric value following Scala's weak conformance" in {
+      val m = mock[NumericReturns]
+
+      val b: Byte  = 1
+      val ch: Char = 'A'
+      m.getShort shouldReturn b // Byte widens to Short
+      m.getInt mustReturn ch    // Char widens to Int
+
+      m.getShort shouldBe 1.toShort
+      m.getInt shouldBe 65
+    }
+
+    "reject widening that Scala's weak conformance does not allow (e.g. Byte to Char)" in {
+      "val m = mock[NumericReturns]; val b: Byte = 1; m.getChar shouldReturn b" shouldNot typeCheck
+      "val m = mock[NumericReturns]; val s: Short = 1; m.getChar shouldReturn s" shouldNot typeCheck
+    }
+
+    "widen and box a numeric value to a Java boxed return type" in {
+      val m = mock[BoxedNumericReturns]
+
+      m.getBoxedInteger shouldReturn 5 // Int -> java.lang.Integer
+      m.getBoxedLong mustReturn 6      // Int widened to Long, boxed
+      m.getBoxedDouble returns 7  // Int widened to Double, boxed
+
+      m.getBoxedInteger shouldBe (5: java.lang.Integer)
+      m.getBoxedLong shouldBe (6L: java.lang.Long)
+      m.getBoxedDouble shouldBe (7.0: java.lang.Double)
+    }
+
+    "widen and box a non-constant numeric value to a Java boxed return type" in {
+      val m = mock[BoxedNumericReturns]
+
+      val i = 8
+      m.getBoxedLong returns i // non-constant Int widened to Long, boxed
+
+      m.getBoxedLong shouldBe (8L: java.lang.Long)
+    }
+
+    "reject boxed numeric stubbing that Scala does not allow (literal narrowing or narrowing)" in {
+      "val m = mock[BoxedNumericReturns]; m.getBoxedByte shouldReturn 5" shouldNot typeCheck
+      "val m = mock[BoxedNumericReturns]; m.getBoxedInteger shouldReturn 5L" shouldNot typeCheck
     }
 
     "stub a map" in {

--- a/scalatest/src/test/scala/user/org/mockito/TestModel.scala
+++ b/scalatest/src/test/scala/user/org/mockito/TestModel.scala
@@ -82,9 +82,13 @@ class Org {
 
   def returnBar: Bar = new Bar
 
+  def returnsATuple: (Int, String) = (-1, "not mocked")
+
   def highOrderFunction(f: Int => String): String = "not mocked"
 
   def iReturnAFunction(v: Int): Int => String = i => (i * v).toString
+
+  def iReturnAPartialFunction(v: Int): PartialFunction[Int, String] = { case i => (i * v).toString }
 
   def iBlowUp(v: Int, v2: String): String = throw new IllegalArgumentException("I was called!")
 


### PR DESCRIPTION
Upgrade the Scala 3 LTS from 3.3.7 to 3.3.8.

3.3.8 backported an overload-resolution change that made the `shouldReturn` / `mustReturn` extensions in `IdiomaticStubbing` (Scala 3) ambiguous (#661 fails because of this).

Fix: route `shouldReturn` / `mustReturn` / `returns` through a single value-taking form. Beyond removing the ambiguity, this aligns the Scala 3 stubbing DSL with Scala 2, so it now consistently:

• infers polymorphic-method type parameters from the stubbed value (#652), now including `returns`
• widens narrower numeric values to the method's return type (e.g. stub a  Long  method with  1 ), fixing a runtime  `ClassCastException` 
• narrows in-range Int  literal constants to Byte / Short / Char , following Scala's numeric conformance
• rejects genuine type mismatches at compile time
• keeps multi-value (consecutive) stubbing and stubbing of function / partial-function returns

